### PR TITLE
added dynamic emsdk path and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ GTO BioChef is a powerful web-based application for genomic sequence analysis an
 
 ## Table of Contents
 
+- [Table of Contents](#table-of-contents)
 - [Features](#features)
 - [Tools Available](#tools-available)
 - [Getting Started](#getting-started)
@@ -16,6 +17,7 @@ GTO BioChef is a powerful web-based application for genomic sequence analysis an
   - [Installation](#installation)
 - [Usage](#usage)
 - [Development](#development)
+  - [Key Files](#key-files)
 - [Contributing](#contributing)
 - [License](#license)
 - [Acknowledgments](#acknowledgments)
@@ -64,17 +66,27 @@ GTO BioChef includes a wide array of genomic tools, categorized for easy access:
    npm install
    ```
 
-3. Compile GTO tools to WebAssembly:
+3. Install Emscripten SDK:
+   Download and install the Emscripten SDK from the [official repository](https://github.com/emscripten-core/emsdk). (Preferably the 3.1.65 version)
+
+4. Setup Emscripten Environment Variable:
+   ```
+   nano ~/.bashrc
+   export EMSDK_PATH="/path/to/your/emsdk"
+   source ~/.bashrc
+   ```
+
+5. Compile GTO tools to WebAssembly:
    ```
    npm run build-wasm
    ```
 
-4. Start the development server:
+6. Start the development server:
    ```
    npm start
    ```
 
-5. Open your browser and navigate to `http://localhost:8082`.
+7. Open your browser and navigate to `http://localhost:8082`.
 
 For more detailed installation instructions, including troubleshooting tips, please see our [Installation Guide](docs/INSTALLATION.md).
 

--- a/compile-all-gto.sh
+++ b/compile-all-gto.sh
@@ -6,8 +6,11 @@ set +e
 # Get the directory of the script
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-# Set the path to the emsdk directory
-EMSDK_PATH="/home/jake/Desktop/Uni/Bolsa/emsdk"
+# Check if EMSDK_PATH is set as an environment variable
+if [[ -z "$EMSDK_PATH" ]]; then
+    echo "Error: EMSDK_PATH is not set. Please configure it before running the script."
+    exit 1
+fi
 
 # Ensure Emscripten is in the PATH
 source "$EMSDK_PATH/emsdk_env.sh"


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to improve the setup instructions and a modification to the `compile-all-gto.sh` script to check for the `EMSDK_PATH` environment variable. The most important changes include adding new setup steps for Emscripten SDK and ensuring environment variables are checked before running scripts.

Updates to setup instructions:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L67-R89): Added steps to install Emscripten SDK and set up the Emscripten environment variable. Updated the numbering for subsequent steps accordingly.

Script improvements:

* [`compile-all-gto.sh`](diffhunk://#diff-efdf1e0d473b8de24f3318a5f8710e4e087235ad7df5826088dbe99ca487cd6dL9-R13): Added a check to ensure `EMSDK_PATH` is set as an environment variable before running the script.