### PR TITLE
fixed gto_new_line_on_new_x input type

### DIFF
--- a/description.json
+++ b/description.json
@@ -2228,11 +2228,11 @@
       "description": "Splits different rows with a new empty row.",
       "input": {
         "type": "stdin",
-        "format": "SEQ"
+        "format": "NUM"
       },
       "output": {
         "type": "stdout",
-        "format": "SEQ"
+        "format": "NUM"
       },
       "flags": [
         {


### PR DESCRIPTION
This pull request includes a change to the `description.json` file to modify the input and output format types.

* [`description.json`](diffhunk://#diff-f005b3129fcdafd751577628d7097c5a8425a3436a7a96423188558a63b577d7L2231-R2235): Changed the `format` for both `input` and `output` from `SEQ` to `NUM`.