### PR TITLE
Fix Biochef #77 frontend data type metadata

### DIFF
--- a/src/components/FileExplorer.js
+++ b/src/components/FileExplorer.js
@@ -41,6 +41,7 @@ import JSZip from 'jszip';
 import React, { useContext, useRef, useState } from 'react';
 import { DataTypeContext } from '../contexts/DataTypeContext';
 import { NotificationContext } from '../contexts/NotificationContext';
+import { getUploadExtensions } from '../utils/typeDefinitions';
 import { processFile } from '../utils/fileProcessor';
 
 const FileExplorer = ({ selectedFiles, setSelectedFiles, tree, setTree }) => {
@@ -61,8 +62,7 @@ const FileExplorer = ({ selectedFiles, setSelectedFiles, tree, setTree }) => {
     const { validateData } = useContext(DataTypeContext);
     const showNotification = useContext(NotificationContext);
 
-    // Define acceptable file extensions
-    const acceptableExtensions = ['.fasta', '.fa', '.fastq', '.fq', '.pos', '.svg', '.txt', '.num'];
+    const acceptableExtensions = getUploadExtensions();
 
     // Function to insert files into a folder
     const insertFilesIntoFolder = (nodes, folderId, newFiles) => {

--- a/src/components/ToolInputPanel.js
+++ b/src/components/ToolInputPanel.js
@@ -5,8 +5,8 @@ import { getTool } from '../utils/toolUtils';
 import { DataTypeContext } from '../contexts/DataTypeContext';
 import { NotificationContext } from '../contexts/NotificationContext';
 import { detectDataType } from '../utils/detectDataType';
+import { getUploadExtensions, getExample } from '../utils/typeDefinitions';
 import { TourContext } from '../contexts/TourContext';
-import { exampleInputs } from '../utils/exampleInputs';
 
 const ToolInputPanel = ({ tool, inputData, setInputData }) => {
     const [fileName, setFileName] = useState('');
@@ -53,8 +53,7 @@ const ToolInputPanel = ({ tool, inputData, setInputData }) => {
         ]);
     }, []);
 
-    // Define acceptable file extensions
-    const acceptableExtensions = ['.fasta', '.fa', '.fastq', '.fq', '.pos', '.svg', '.txt', '.num'];
+    const acceptableExtensions = getUploadExtensions();
 
     // Get the input formats supported by the tool
     useEffect(() => {
@@ -92,7 +91,7 @@ const ToolInputPanel = ({ tool, inputData, setInputData }) => {
     const handleInputFormatChange = (format) => {
         updateSelectedInputFormat(format);
 
-        const example_input = exampleInputs[format] || ''
+        const example_input = getExample(format);
         updateSelectedInputData(example_input); // Load example input if available
     };
 
@@ -103,7 +102,7 @@ const ToolInputPanel = ({ tool, inputData, setInputData }) => {
         const lines = isPartial ? content.split('\n').slice(0, 100).join('\n') : content;
         updateSelectedInputData(lines);
 
-        const detectedType = detectDataType(file.name, lines);
+        const detectedType = detectDataType(lines);
         setInputDataType(detectedType);
         const valid = validateData(lines, detectedType);
         setIsValid(valid);

--- a/src/components/ToolInputPanel.js
+++ b/src/components/ToolInputPanel.js
@@ -5,7 +5,7 @@ import { getTool } from '../utils/toolUtils';
 import { DataTypeContext } from '../contexts/DataTypeContext';
 import { NotificationContext } from '../contexts/NotificationContext';
 import { detectDataType } from '../utils/detectDataType';
-import { getUploadExtensions, getExample } from '../utils/typeDefinitions';
+import { getUploadExtensions, getTypeExampleInput } from '../utils/typeDefinitions';
 import { TourContext } from '../contexts/TourContext';
 
 const ToolInputPanel = ({ tool, inputData, setInputData }) => {
@@ -91,7 +91,7 @@ const ToolInputPanel = ({ tool, inputData, setInputData }) => {
     const handleInputFormatChange = (format) => {
         updateSelectedInputFormat(format);
 
-        const example_input = getExample(format);
+        const example_input = getTypeExampleInput(format);
         updateSelectedInputData(example_input); // Load example input if available
     };
 

--- a/src/components/nodes/WorkflowEdge.js
+++ b/src/components/nodes/WorkflowEdge.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { BaseEdge, getBezierPath, useNodesData, useReactFlow } from '@xyflow/react';
 import { isValidWorkflowConnection } from '../../utils/workflowUtils';
+import { getEdgeColor } from '../../utils/typeDefinitions';
 
 export function WorkflowEdge(props) {
   const {
@@ -25,19 +26,6 @@ export function WorkflowEdge(props) {
     targetPosition,
   });
 
-  const typeColors = {
-    FASTA: "#e74c3c",
-    "Multi-FASTA": "#d35400",
-    FASTQ: "#e67e22",
-    DNA: "#9b59b6",
-    RNA: "#8e44ad",
-    AminoAcids: "#16a085",
-    NUM: "#3498db",
-    PackagedFASTQ: "#2c3e50",
-    TEXT: "#2ecc71",
-    BIN: "#123456"
-  };
-
   useEffect(() => {
     const sourceNode = getNode(source);
     const targetNode = getNode(target);
@@ -58,10 +46,7 @@ export function WorkflowEdge(props) {
     updateNodeData(target, { inputValidity });
 
     // compute colors here
-    const selectedColor =
-      handleType && typeColors.hasOwnProperty(handleType)
-        ? typeColors[handleType]
-        : "#999";
+    const selectedColor = getEdgeColor(handleType);
 
     const nextColor = isValidConnection ? selectedColor : "#ff0000";
     const nextLabel = isValidConnection

--- a/src/utils/detectDataType.js
+++ b/src/utils/detectDataType.js
@@ -1,3 +1,5 @@
+import { getTypeDefinitions } from './typeDefinitions';
+
 function validateFasta(content) {
   const lines = content?.trim().split('\n');
   if (!lines || lines[0][0] !== '>') return false;
@@ -8,7 +10,7 @@ function validateFasta(content) {
 
 function validateMultiFasta(content) {
   if (!content) return false
-  
+
   const headerCount = (content.match(/>/g) || []).length;
   const entries = content.split('>').filter(entry => entry.trim());
   if (headerCount !== entries.length) {
@@ -72,19 +74,26 @@ function validateBin(content) {
   return lines.every(line => /^[01]+$/.test(line.trim()));
 }
 
+const validators = {
+  fasta: validateFasta,
+  multiFasta: validateMultiFasta,
+  fastq: validateFastq,
+  packagedFastq: validatePackagedFastq,
+  num: validateNum,
+  bin: validateBin,
+  dna: validateDNA,
+  rna: validateRNA,
+  aminoAcids: validateAminoAcids,
+  text: () => true, // Default fallback for TEXT
+};
+
 // these are in order of priority
-const allTypes = [
-  { type: 'FASTA', validator: validateFasta },
-  { type: 'Multi-FASTA', validator: validateMultiFasta },
-  { type: 'FASTQ', validator: validateFastq },
-  { type: 'Packaged FASTQ', validator: validatePackagedFastq },
-  { type: 'NUM', validator: validateNum },
-  { type: 'BIN', validator: validateBin },
-  { type: 'DNA', validator: validateDNA },
-  { type: 'RNA', validator: validateRNA },
-  { type: 'AminoAcids', validator: validateAminoAcids },
-  { type: 'TEXT', validator: () => true }, // Default fallback for TEXT
-];
+const allTypes = getTypeDefinitions()
+  .map(typeDef => ({
+    type: typeDef.id,
+    validator: validators[typeDef.validator],
+  }))
+  .filter(typeDef => typeDef.validator);
 
 // Function to detect data type with priority from the allowed types
 export function detectDataType(data, allowed = []) {

--- a/src/utils/fileProcessor.js
+++ b/src/utils/fileProcessor.js
@@ -1,7 +1,7 @@
 import { detectDataType } from './detectDataType';
+import { getUploadExtensions } from './typeDefinitions';
 
-// Define acceptable file extensions
-export const acceptableExtensions = ['.fasta', '.fa', '.fastq', '.fq', '.pos', '.svg', '.txt', '.num'];
+export const acceptableExtensions = getUploadExtensions();
 
 const readFirstNLines = (file, maxLines = 100) => {
     return new Promise((resolve, reject) => {
@@ -97,7 +97,7 @@ export const processFile = async (file, validateData, showNotification) => {
             });
         }
 
-        const detectedType = detectDataType(file.name, content);
+        const detectedType = detectDataType(content);
 
         if (!validateData(content, detectedType) && detectedType !== 'UNKNOWN') {
             showNotification(`Invalid ${detectedType} data format in ${file.name}.`, 'error');

--- a/src/utils/typeDefinitions.js
+++ b/src/utils/typeDefinitions.js
@@ -1,0 +1,137 @@
+export const typeDefinitions = [
+  {
+    id: 'FASTA',
+    validator: 'fasta',
+    defaultExtension: '.fasta',
+    scriptExtension: 'fa',
+    uploadExtensions: ['.fasta', '.fa'],
+    edgeColor: '#e74c3c',
+    example: '>seq\nTTGCACTGACCTGAAGTCTTGGAGTATGACCGCGGCTCGGCTCTATCGAACGCTCGATCTAGCGCTATAGGTGGTGCCGAAGGCGGTCTGTCGTCGTA',
+  },
+  {
+    id: 'Multi-FASTA',
+    validator: 'multiFasta',
+    defaultExtension: '.fasta',
+    scriptExtension: 'fa',
+    uploadExtensions: ['.fasta', '.fa'],
+    edgeColor: '#d35400',
+    example: '>seq1\nGTTCCAGTAGCGGCGTATCGTAGGTGACGTAGCAGTCGATCGCTAGCGAAGCGCTGACTAGCTCGATAGCGGCTACTCGTACGTAGTACGTAGCATACG\n>seq2\nAGCTGCTGATCGTGATCGAGCTCGATGCATCGATCGCTAGCGTACGTAGCTGACGTAGCGTGACTGATCGTAGCTGATCGTGACGTAGCTGACGTAGCTG',
+  },
+  {
+    id: 'FASTQ',
+    validator: 'fastq',
+    defaultExtension: '.fastq',
+    scriptExtension: 'fq',
+    uploadExtensions: ['.fastq', '.fq'],
+    edgeColor: '#e67e22',
+    example: '@seq\nGCTAGCTGATCGTACGTAGCGTATCGTAGCTGATCGTACGATCGTAGCTAGCTGATCGTAGCTAGCTAGCTGATCGTAGCTAGCTGATCGTACGTAGC\n+\n!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~!!!!!',
+  },
+  {
+    id: 'PackagedFASTQ',
+    validator: 'packagedFastq',
+    defaultExtension: '.txt',
+    uploadExtensions: ['.txt'],
+    edgeColor: '#2c3e50',
+    example: 'GATTTGGGGTTCAAAGCAGTATCGATCAAATAGTAAATCCATTTGTTCAACTCACAGTTT\x7F!\'\'*((((***+))%%%++)(%%%%).1***-+*\'\'))**55CCF>>>>>>CCCCCCC6\x7FSEQ_ID\x7F+\x7F\t0',
+  },
+  {
+    id: 'NUM',
+    validator: 'num',
+    defaultExtension: '.num',
+    uploadExtensions: ['.num'],
+    edgeColor: '#3498db',
+    example: '0.123\n3.432\n2.341\n1.323\n7.538\n4.122\n0.242\n0.654\n5.633',
+  },
+  {
+    id: 'BIN',
+    validator: 'bin',
+    defaultExtension: '.bin',
+    uploadExtensions: ['.bin'],
+    edgeColor: '#123456',
+    example: '0\n1\n0',
+  },
+  {
+    id: 'DNA',
+    validator: 'dna',
+    defaultExtension: '.txt',
+    uploadExtensions: ['.txt'],
+    edgeColor: '#9b59b6',
+    example: 'CGTACGTAGCTGACTGATCGTAGCTAGCTGACTGACTAGCTGATCGTAGCTGATCGTACGTAGCTAGCTAGCTGACTAGCTGATCGTACGTAGCTGAC',
+  },
+  {
+    id: 'RNA',
+    validator: 'rna',
+    defaultExtension: '.txt',
+    uploadExtensions: ['.txt'],
+    edgeColor: '#8e44ad',
+    example: 'CGUACGUAGCUGACUGAUCGAUGCUACGUAGCUGACGUAGCUAGCUAGCUAGCUAGCUAGCUAGCUAGCUAGCUAGCUAGCUAGCUAGCUAGCUAGCUA',
+  },
+  {
+    id: 'AminoAcids',
+    validator: 'aminoAcids',
+    defaultExtension: '.txt',
+    uploadExtensions: ['.txt'],
+    edgeColor: '#16a085',
+    example: 'ACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTVWYACDEFGHIKLMNPQRSTV',
+  },
+  {
+    id: 'TEXT',
+    validator: 'text',
+    defaultExtension: '.txt',
+    uploadExtensions: ['.txt'],
+    edgeColor: '#2ecc71',
+    example: 'Hello, World',
+  },
+  {
+    id: 'POS',
+    validator: 'pos',
+    defaultExtension: '.pos',
+    uploadExtensions: ['.pos'],
+    edgeColor: '#7f8c8d',
+    example: '1 10\n2 20',
+  },
+  {
+    id: 'SVG',
+    validator: 'svg',
+    defaultExtension: '.svg',
+    uploadExtensions: ['.svg'],
+    edgeColor: '#27ae60',
+    example: '<svg width=\'100\' height=\'100\'><rect width=\'100\' height=\'100\' style=\'fill:rgb(0,0,255);stroke-width:3;stroke:rgb(0,0,0)\' /></svg>',
+  },
+  {
+    id: 'Group',
+    validator: 'group',
+    defaultExtension: '.txt',
+    uploadExtensions: ['.txt'],
+    edgeColor: '#34495e',
+    example: 'PNUSH*X',
+  },
+];
+
+export function getTypeDefinitions() {
+  return typeDefinitions;
+}
+
+export function getTypeDefinition(typeId) {
+  return typeDefinitions.find(typeDef => typeDef.id === typeId);
+}
+
+export function getUploadExtensions() {
+  return [...new Set(typeDefinitions.flatMap(typeDef => typeDef.uploadExtensions || []))];
+}
+
+export function getDefaultExtension(typeId) {
+  return getTypeDefinition(typeId)?.defaultExtension || '.txt';
+}
+
+export function getScriptExtension(typeId) {
+  return getTypeDefinition(typeId)?.scriptExtension || getDefaultExtension(typeId).replace(/^\./, '');
+}
+
+export function getExample(typeId) {
+  return getTypeDefinition(typeId)?.example || '';
+}
+
+export function getEdgeColor(typeId) {
+  return getTypeDefinition(typeId)?.edgeColor || '#999';
+}

--- a/src/utils/typeDefinitions.js
+++ b/src/utils/typeDefinitions.js
@@ -128,7 +128,7 @@ export function getScriptExtension(typeId) {
   return getTypeDefinition(typeId)?.scriptExtension || getDefaultExtension(typeId).replace(/^\./, '');
 }
 
-export function getExample(typeId) {
+export function getTypeExampleInput(typeId) {
   return getTypeDefinition(typeId)?.example || '';
 }
 


### PR DESCRIPTION
Fixes #77. Related to https://github.com/ieeta-pt/biochef-hub/pull/5

Centralizes frontend data type metadata so type ids, examples, upload extensions, script extensions, and edge colors are easier to keep consistent when adding new data types.

## Changes

- Adds shared frontend type metadata helpers.
- Replaces duplicated hardcoded upload extension lists.
- Reuses centralized edge colors for workflow edges.
- Keeps frontend content detection based on the existing validators.
