### PR TITLE
Binary I/O across workflow edges

### DIFF
--- a/src/components/InputPanel.js
+++ b/src/components/InputPanel.js
@@ -15,6 +15,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import { DataTypeContext } from '../contexts/DataTypeContext';
 import { NotificationContext } from '../contexts/NotificationContext';
 import { detectDataType } from '../utils/detectDataType';
+import { isDataValue, makeText } from '../utils/dataValue';
 import FileExplorer from './FileExplorer';
 import { TourContext } from '../contexts/TourContext';
 import { exampleInputs } from '../utils/exampleInputs';
@@ -25,7 +26,19 @@ const InputPanel = ({ tabIndex, setTabIndex, selectedFiles, setSelectedFiles, in
     const { setInputDataType, validateData, inputDataType } = useContext(DataTypeContext);
     const [isValid, setIsValid] = useState(true);
     const [debounceTimer, setDebounceTimer] = useState(null);
-    const numberOfLines = inputData.split('\n').length;
+    // For rendering: extract text payload; binary inputs get a placeholder string.
+    const displayText = (() => {
+        if (inputData === undefined || inputData === null) return '';
+        if (isDataValue(inputData)) {
+            if (inputData.kind === 'binary') {
+                const len = inputData.data?.length ?? 0;
+                return `[binary ${inputData.type || 'BIN'}, ${len} bytes - pre-loaded, not editable here]`;
+            }
+            return inputData.data ?? '';
+        }
+        return inputData;
+    })();
+    const numberOfLines = displayText.split('\n').length;
 
     const [selectedExampleFormat, setSelectedExampleFormat] = useState('');
 
@@ -36,27 +49,35 @@ const InputPanel = ({ tabIndex, setTabIndex, selectedFiles, setSelectedFiles, in
 
         if (selectedFiles.size == 0) {
             setInputDataType('UNKNOWN');
-            if (inputData != '') setInputData('')
+            const isEmpty = inputData === '' || (isDataValue(inputData) && (inputData.data?.length ?? 0) === 0);
+            if (!isEmpty) setInputData('')
             return
         }
 
         // File Manager Mode: derive type from selected files.
-        // Compute the set of file types from selected files.
         const fileTypes = new Set(
             Array.from(selectedFiles).map(file => file.fileType)
         );
-        // If there's exactly one type, update inputDataType.
         if (fileTypes.size === 1) {
             setInputDataType([...fileTypes][0]);
         } else {
-            // Otherwise, either leave it unchanged or set it to a fallback value.
             setInputDataType('UNKNOWN');
         }
 
-        // NOTE(andrade)
-        // Not sure if concatenating the files is the correct thing to do
-        // Maybe we want to limit to one selected file at a time
-        setInputData(Array.from(selectedFiles).map(f => f.content).join('\n'));
+        // file.content is now a DataValue ({kind:"text"|"binary"}). Concat-by-newline
+        // only makes sense for text. For binary, hand the first selected file's
+        // DataValue through unchanged (binary streams aren't line-concatenable).
+        const files = Array.from(selectedFiles);
+        const anyBinary = files.some(f => isDataValue(f.content) && f.content.kind === 'binary');
+        if (anyBinary) {
+            const first = files.find(f => isDataValue(f.content) && f.content.kind === 'binary');
+            setInputData(first.content);
+        } else {
+            const joined = files
+                .map(f => isDataValue(f.content) ? (f.content.data ?? '') : (f.content ?? ''))
+                .join('\n');
+            setInputData(joined);
+        }
     }, [selectedFiles]);
 
     const handleTabChange = (event, newIndex) => {
@@ -250,7 +271,7 @@ const InputPanel = ({ tabIndex, setTabIndex, selectedFiles, setSelectedFiles, in
 
                                 <TextField
                                     variant="outlined"
-                                    value={inputData}
+                                    value={displayText}
                                     onChange={handleTextChange}
                                     placeholder="e.g., >Sequence1\nACGT..."
                                     InputProps={{
@@ -284,7 +305,7 @@ const InputPanel = ({ tabIndex, setTabIndex, selectedFiles, setSelectedFiles, in
                                 }}
                             >
                                 <Typography variant="caption" color="textSecondary" sx={{ marginRight: 'auto' }}>
-                                    {inputData.length}/100000 characters, {numberOfLines} lines
+                                    {displayText.length}/100000 characters, {numberOfLines} lines
                                 </Typography>
                             </Box>
                         </Box>

--- a/src/components/RecipePanel.js
+++ b/src/components/RecipePanel.js
@@ -12,6 +12,8 @@ import { NotificationContext } from '../contexts/NotificationContext';
 import { isValidWorkflowConnection, sanitizeWorkflowNodes } from '../utils/workflowUtils';
 import logger from '../utils/logger';
 import { resolveCollisions } from '../utils/resolveNodeCollisions';
+import { externalizeBinaryOutputs, hydrateBinaryOutputs, gcOrphans, stripBinaryForExport } from '../utils/persistBinary';
+import { prepareWorkflowForAgent } from '../utils/agentContract';
 
 const RecipePanel = forwardRef(({ selectedNode, setSelectedNode, handleNodeClicked, indexLoaded }, ref) => {
   const [nodes, setNodes] = useNodesState([]);
@@ -32,9 +34,14 @@ const RecipePanel = forwardRef(({ selectedNode, setSelectedNode, handleNodeClick
     if (!indexLoaded) return;
 
     const fetchWorkflow = async () => {
-      const flow = JSON.parse(localStorage.getItem("workflow"));
+      let flow = JSON.parse(localStorage.getItem("workflow"));
 
       if (flow) {
+        // Swap any binary-ref markers in the saved JSON back for real
+        // DataValues by fetching their bytes from IndexedDB.
+        try { flow = await hydrateBinaryOutputs(flow); }
+        catch (e) { logger.error("hydrateBinaryOutputs failed", e); }
+
         const { nodes: savedNodes = [], edges: savedEdges = [], viewport = {} } = flow;
 
         for (const node of savedNodes) {
@@ -76,10 +83,26 @@ const RecipePanel = forwardRef(({ selectedNode, setSelectedNode, handleNodeClick
   useEffect(() => {
     if (!workflowLoaded) return;
 
+    let cancelled = false;
     const flow = toObject();
-    flow.nodes = sanitizeWorkflowNodes(flow.nodes)
+    flow.nodes = sanitizeWorkflowNodes(flow.nodes);
 
-    localStorage.setItem('workflow', JSON.stringify(flow));
+    // Externalise any binary DataValues to IndexedDB before stringifying;
+    // JSON.stringify on a raw Uint8Array silently drops the bytes, so we
+    // store refs in localStorage and the actual bytes elsewhere.
+    (async () => {
+      try {
+        const { flow: externalized } = await externalizeBinaryOutputs(flow);
+        if (cancelled) return;
+        localStorage.setItem('workflow', JSON.stringify(externalized));
+        // Drop orphaned blobs whose ids aren't referenced anywhere.
+        gcOrphans(externalized).catch(e => logger.error("gcOrphans failed", e));
+      } catch (e) {
+        logger.error("externalizeBinaryOutputs failed", e);
+        // Last-resort: skip persistence rather than corrupt localStorage.
+      }
+    })();
+    return () => { cancelled = true; };
   }, [nodes, edges]);
 
   useEffect(() => {
@@ -214,9 +237,15 @@ const RecipePanel = forwardRef(({ selectedNode, setSelectedNode, handleNodeClick
   const exportWorkflow = useCallback(() => {
     if (nodes.length === 0) return;
 
-    const flow = toObject();
+    let flow = toObject();
     flow.nodes = sanitizeWorkflowNodes(flow.nodes);
-    const fileContent = JSON.stringify(flow, null, 2);
+    // Strip binary outputs from the exported file. Embedding raw bytes would
+    // bloat the JSON and binary-refs are useless on a different device.
+    const { flow: exportable, strippedAny } = stripBinaryForExport(flow);
+    if (strippedAny) {
+      showNotification("Binary input data was stripped from the exported workflow file.", "info");
+    }
+    const fileContent = JSON.stringify(exportable, null, 2);
 
     const blob = new Blob([fileContent], { type: 'application/json' });
     const url = URL.createObjectURL(blob);
@@ -227,7 +256,7 @@ const RecipePanel = forwardRef(({ selectedNode, setSelectedNode, handleNodeClick
     a.click();
 
     URL.revokeObjectURL(url);
-  }, [nodes, toObject]);
+  }, [nodes, toObject, showNotification]);
 
   // Import Workflow function
   const importWorkflow = useCallback(() => {
@@ -243,7 +272,29 @@ const RecipePanel = forwardRef(({ selectedNode, setSelectedNode, handleNodeClick
         const text = await file.text();
         const flow = JSON.parse(text);
 
-        const { nodes: importedNodes = [], edges: importedEdges = [], viewport = {} } = flow;
+        let { nodes: importedNodes = [], edges: importedEdges = [], viewport = {} } = flow;
+
+        // Imported workflows can contain placeholder markers that don't carry
+        // usable data on this machine: `binary-stripped` (export removed bytes)
+        // or `binary-ref` (refs to a *different* device's IndexedDB). Scrub
+        // both so they don't leak into edge values silently.
+        let scrubbed = false;
+        importedNodes = importedNodes.map(node => {
+          const outs = node.data?.outputs;
+          if (!outs || typeof outs !== "object") return node;
+          const newOuts = {};
+          for (const [k, v] of Object.entries(outs)) {
+            if (v && typeof v === "object" && (v.kind === "binary-stripped" || v.kind === "binary-ref")) {
+              scrubbed = true;
+            } else {
+              newOuts[k] = v;
+            }
+          }
+          return { ...node, data: { ...node.data, outputs: newOuts } };
+        });
+        if (scrubbed) {
+          showNotification("Imported workflow had binary inputs missing on this device. Re-upload them to run.", "info");
+        }
 
         for (const node of importedNodes) {
           if (node.type === 'workflowNode') {
@@ -285,55 +336,45 @@ const RecipePanel = forwardRef(({ selectedNode, setSelectedNode, handleNodeClick
   }
 
   async function runWorkflowAgent(url) {
-    let fileData = {}
-    for (const node of nodes) {
-      if (node.type == "inputWorkflowNode") {
-        fileData[node.id + "-out" + ".txt"] = node.data.outputs["out"]
-      }
-    }
-
-    const formData = new FormData();
-
     const flow = toObject();
     flow.nodes = sanitizeWorkflowNodes(flow.nodes);
-    formData.append("biochef_workflow", JSON.stringify(flow));
 
-    for (const [filename, content] of Object.entries(fileData)) {
-      const file = new File([content], filename, { type: "text/plain" });
-      formData.append("files", file);
-    }
+    // Split DataValues across the multipart payload: the workflow JSON gets
+    // file-ref markers, and the actual bytes go into the files slot with a
+    // declared MIME type so any tool running on the agent sees real binary.
+    const { workflowJSON, files } = prepareWorkflowForAgent(flow);
 
-    let response = null
+    const formData = new FormData();
+    formData.append("biochef_workflow", workflowJSON);
+    for (const file of files) formData.append("files", file);
+
+    let response = null;
     try {
-      response = await fetch(url, {
-        method: "POST",
-        body: formData
-      });
+      response = await fetch(url, { method: "POST", body: formData });
+    } catch {
+      logger.error("Could not send request to agent");
+      showNotification("Agent could not be reached", "error");
+      return;
     }
-    catch {
-      logger.error("Could not send request to agent")
-      showNotification("Agent could not be reached", "error")
-      return
-    }
-
     if (!response) {
-      logger.error("Did not get a response from agent agent")
-      showNotification("Agent did not responde", "error")
-      return
+      logger.error("Did not get a response from agent");
+      showNotification("Agent did not respond", "error");
+      return;
     }
 
-    let data = null
-    try {
-      data = await response.json();
-    }
+    let data = null;
+    try { data = await response.json(); }
     catch {
-      logger.error("Could not process response from agent")
-      showNotification("Invalid reponse from agent", "error")
-      return
+      logger.error("Could not process response from agent");
+      showNotification("Invalid response from agent", "error");
+      return;
     }
 
+    // Agent response shape: { node_id: { outputs: {...} } }. Currently the
+    // response is JSON-only; if we ever need to receive binary back we'd add
+    // a separate multipart channel coming from the agent.
     for (const [node_id, outputs] of Object.entries(data)) {
-      updateNodeData(node_id, { outputs })
+      updateNodeData(node_id, { outputs });
     }
   }
 

--- a/src/components/ToolInputPanel.js
+++ b/src/components/ToolInputPanel.js
@@ -4,9 +4,10 @@ import React, { useContext, useEffect, useState } from 'react';
 import { getTool } from '../utils/toolUtils';
 import { DataTypeContext } from '../contexts/DataTypeContext';
 import { NotificationContext } from '../contexts/NotificationContext';
-import { detectDataType } from '../utils/detectDataType';
+import { detectDataType, isLikelyBinaryFile, detectBinaryType } from '../utils/detectDataType';
 import { TourContext } from '../contexts/TourContext';
 import { exampleInputs } from '../utils/exampleInputs';
+import { makeBinary } from '../utils/dataValue';
 
 const ToolInputPanel = ({ tool, inputData, setInputData }) => {
     const [fileName, setFileName] = useState('');
@@ -53,8 +54,12 @@ const ToolInputPanel = ({ tool, inputData, setInputData }) => {
         ]);
     }, []);
 
-    // Define acceptable file extensions
-    const acceptableExtensions = ['.fasta', '.fa', '.fastq', '.fq', '.pos', '.svg', '.txt', '.num'];
+    // Define acceptable file extensions (text + binary HTS formats)
+    const acceptableExtensions = [
+        '.fasta', '.fa', '.fastq', '.fq', '.pos', '.svg', '.txt', '.num',
+        '.vcf', '.bed', '.gff', '.gtf', '.sam', '.json', '.tsv',
+        '.bam', '.bcf', '.cram', '.bai', '.csi', '.tbi', '.gzi', '.mmi', '.fai', '.gz', '.bgz',
+    ];
 
     // Get the input formats supported by the tool
     useEffect(() => {
@@ -126,6 +131,24 @@ const ToolInputPanel = ({ tool, inputData, setInputData }) => {
                 setInputData({});
                 setIsValid(false);
                 setInputDataType('UNKNOWN'); // Reset data type
+                return;
+            }
+
+            // Binary path: read as ArrayBuffer; emit DataValue{kind:"binary"}.
+            if (isLikelyBinaryFile(file.name)) {
+                const reader = new FileReader();
+                reader.onload = (e) => {
+                    const bytes = new Uint8Array(e.target.result);
+                    const detectedType = detectBinaryType(bytes, file.name);
+                    setInputDataType(detectedType);
+                    setIsValid(true);
+                    updateSelectedInputData(makeBinary(bytes, detectedType));
+                };
+                reader.onerror = (e) => {
+                    console.error('Error reading file:', e);
+                    showNotification('Failed to read the file.', 'error');
+                };
+                reader.readAsArrayBuffer(file);
                 return;
             }
 
@@ -264,7 +287,18 @@ const ToolInputPanel = ({ tool, inputData, setInputData }) => {
             <Box sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', padding: 2 }}>
                 <TextField
                     variant="outlined"
-                    value={inputData[selectedInput.name] || ''}
+                    value={(() => {
+                        const v = inputData[selectedInput.name];
+                        if (v === undefined || v === null) return '';
+                        if (typeof v === 'object' && 'kind' in v && 'data' in v) {
+                            if (v.kind === 'binary') {
+                                const len = v.data?.length ?? 0;
+                                return `[binary ${v.type || 'BIN'}, ${len} bytes - pre-loaded, not editable here]`;
+                            }
+                            return v.data ?? '';
+                        }
+                        return v;
+                    })()}
                     onChange={(e) => handleTextChange(e.target.value)}
                     placeholder="e.g., >Sequence1\nACGT..."
                     InputProps={{
@@ -296,7 +330,18 @@ const ToolInputPanel = ({ tool, inputData, setInputData }) => {
                 }}
             >
                 <Typography variant="body2" color="textSecondary">
-                    {(inputData[selectedInput.name]?.length || 0)}/100000 characters, {(inputData[selectedInput.name]?.split('\n').length || 0)} lines
+                    {(() => {
+                        const v = inputData[selectedInput.name];
+                        if (v === undefined || v === null) return '0/100000 characters, 0 lines';
+                        let text;
+                        if (typeof v === 'object' && 'kind' in v && 'data' in v) {
+                            if (v.kind === 'binary') return `${v.data?.length ?? 0} bytes (binary)`;
+                            text = v.data ?? '';
+                        } else {
+                            text = v;
+                        }
+                        return `${text.length}/100000 characters, ${text.split('\n').length} lines`;
+                    })()}
                 </Typography>
                 <Tooltip title="Upload File">
                     <IconButton

--- a/src/components/ToolOutputPanel.js
+++ b/src/components/ToolOutputPanel.js
@@ -4,6 +4,11 @@ import { saveAs } from 'file-saver';
 import JSZip from 'jszip';
 import React, { useEffect, useState, useContext } from 'react';
 import { TourContext } from '../contexts/TourContext';
+import { isDataValue } from '../utils/dataValue';
+
+// Map declared binary types to a sensible download MIME + extension.
+const BINARY_MIME = { BAM: 'application/x-bam', BCF: 'application/x-bcf', CRAM: 'application/x-cram', BIN: 'application/octet-stream' };
+const BINARY_EXT  = { BAM: '.bam', BCF: '.bcf', CRAM: '.cram', BIN: '.bin' };
 
 const ToolOutputPanel = ({ outputData, setOutputData, workflow = null, tool = null, inputData, page, rows=8 }) => {
     const [selectedFile, setSelectedFile] = useState('');
@@ -30,27 +35,38 @@ const ToolOutputPanel = ({ outputData, setOutputData, workflow = null, tool = nu
     }, []);
 
 
+    const renderableText = (value) => {
+        if (value === undefined || value === null) return '';
+        if (isDataValue(value)) {
+            // Don't try to dump raw bytes into the textarea.
+            if (value.kind === 'binary') {
+                const len = value.data?.length ?? 0;
+                return `[binary ${value.type || 'BIN'}, ${len} bytes - use Save to download]`;
+            }
+            return value.data ?? '';
+        }
+        return value;
+    };
+
     // Update displayed output when outputData or selectedFile changes
     useEffect(() => {
-        if (typeof outputData === 'object' && !Array.isArray(outputData)) {
-            // For object type outputs (multiple files)
+        // Multi-file object case (NOT a single DataValue object)
+        if (typeof outputData === 'object' && outputData !== null && !Array.isArray(outputData) && !isDataValue(outputData)) {
             if (Object.keys(outputData).length > 0) {
-                // If we have a selected file and it exists in the outputData, use it
                 if (selectedFile && outputData[selectedFile]) {
-                    setDisplayedOutput(outputData[selectedFile]);
+                    setDisplayedOutput(renderableText(outputData[selectedFile]));
                 } else {
-                    // Otherwise select the first file
                     const firstKey = Object.keys(outputData)[0];
                     setSelectedFile(firstKey);
-                    setDisplayedOutput(outputData[firstKey]);
+                    setDisplayedOutput(renderableText(outputData[firstKey]));
                 }
             } else {
                 setDisplayedOutput('');
                 setSelectedFile('');
             }
         } else {
-            // For string type outputs (single file)
-            setDisplayedOutput(outputData);
+            // Single-output case (string OR DataValue)
+            setDisplayedOutput(renderableText(outputData));
             setSelectedFile('');
         }
     }, [outputData, selectedFile]);
@@ -70,17 +86,32 @@ const ToolOutputPanel = ({ outputData, setOutputData, workflow = null, tool = nu
     }, [tool, inputData]);
 
     const handleSaveOutput = () => {
-        if (typeof outputData == 'object') {
+        // Binary DataValue → download as proper binary blob with declared MIME + ext.
+        if (isDataValue(outputData) && outputData.kind === 'binary') {
+            const t = outputData.type || 'BIN';
+            const blob = new Blob([outputData.data], { type: BINARY_MIME[t] || 'application/octet-stream' });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.download = `output${BINARY_EXT[t] || '.bin'}`;
+            link.href = url;
+            link.click();
+            URL.revokeObjectURL(url);
+            return;
+        }
+        if (typeof outputData == 'object' && !isDataValue(outputData)) {
             const zip = new JSZip();
             for (const [filename, content] of Object.entries(outputData)) {
-                zip.file(filename, content);
+                // Each entry can itself be a DataValue or a bare string.
+                const payload = isDataValue(content) ? content.data : content;
+                zip.file(filename, payload);
             }
             zip.generateAsync({ type: 'blob' }).then((content) => {
                 saveAs(content, 'output.zip');
             });
         }
         else {
-            const blob = new Blob([outputData], { type: 'text/plain;charset=utf-8' });
+            const text = isDataValue(outputData) ? (outputData.data ?? '') : outputData;
+            const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
             const url = URL.createObjectURL(blob);
             const link = document.createElement('a');
             link.download = `output.txt`;
@@ -98,7 +129,7 @@ const ToolOutputPanel = ({ outputData, setOutputData, workflow = null, tool = nu
         <Paper elevation={1} sx={{ height: '100%', display: 'flex', flexDirection: 'column' }} data-tour="output">
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: 2, flexShrink: 0 }}>
                 <Typography variant="h6">Output</Typography>
-                {typeof outputData === 'object' && !Array.isArray(outputData) && Object.keys(outputData).length > 1 && (
+                {typeof outputData === 'object' && !Array.isArray(outputData) && !isDataValue(outputData) && Object.keys(outputData).length > 1 && (
                     <FormControl size="small" sx={{ minWidth: 150 }}>
                         <Select
                             value={selectedFile}

--- a/src/components/ToolTestingPanel.js
+++ b/src/components/ToolTestingPanel.js
@@ -23,6 +23,7 @@ import { DataTypeContext } from '../contexts/DataTypeContext';
 import { NotificationContext } from '../contexts/NotificationContext';
 import { runTool } from '../utils/toolUtils';
 import { detectDataType } from '../utils/detectDataType';
+import { isDataValue } from '../utils/dataValue';
 import { processFile } from '../utils/fileProcessor';
 import { validateParameters, getToolHelpMessage } from '../utils/parameterUtils';
 import ToolParameterSection from './ToolParameterSection';
@@ -179,9 +180,19 @@ const ToolTestingPanel = ({ tool, inputData, setOutputData, setIsLoading }) => {
                 }
             });
 
-            // Verify if the input data is compatible with the tool
+            // Verify if the input data is compatible with the tool. Each value
+            // may be a bare string (text input) or a DataValue (text or binary
+            // upload). Binary inputs trust the recipe-declared type; text runs
+            // through detectDataType.
             for (const [key, value] of Object.entries(inputData)) {
-                const inputDataType = detectDataType(value);
+                let inputDataType;
+                if (isDataValue(value)) {
+                    inputDataType = value.kind === 'binary'
+                        ? (value.type || 'BIN')
+                        : detectDataType(value.data ?? '');
+                } else {
+                    inputDataType = detectDataType(value);
+                }
 
                 if (!inputFormats.includes(inputDataType)) {
                     showNotification(

--- a/src/components/nodes/OutputWorkflowNode.js
+++ b/src/components/nodes/OutputWorkflowNode.js
@@ -2,6 +2,7 @@ import React, { memo, useEffect, useState } from 'react';
 import { Position, useNodeConnections, useNodesData, useReactFlow } from '@xyflow/react';
 import { OneConnectionHandle } from './OneConnectionHandle';
 import { detectDataType } from '../../utils/detectDataType';
+import { isDataValue } from '../../utils/dataValue';
 
 export const OutputWorkflowNode = memo(({ id, data }) => {
   const { updateNodeData } = useReactFlow();
@@ -20,9 +21,17 @@ export const OutputWorkflowNode = memo(({ id, data }) => {
 
   useEffect(() => {
     if (!connectionData) return;
-    updateNodeData(id, { 
-      output: connectionData.data.outputs?.[sourceHandle] ?? ""
-    });
+    const raw = connectionData.data.outputs?.[sourceHandle];
+    // Existing consumers expect a primitive string. Unwrap text DataValues so
+    // they keep working; pass binary DataValues through so the renderer can
+    // tell what kind of payload it has and switch to a download UI.
+    let output;
+    if (isDataValue(raw)) {
+      output = raw.kind === "text" ? (raw.data ?? "") : raw;
+    } else {
+      output = raw ?? "";
+    }
+    updateNodeData(id, { output });
   }, [connectionData]);
 
   return (

--- a/src/components/nodes/WorkflowEdge.js
+++ b/src/components/nodes/WorkflowEdge.js
@@ -35,7 +35,16 @@ export function WorkflowEdge(props) {
     NUM: "#3498db",
     PackagedFASTQ: "#2c3e50",
     TEXT: "#2ecc71",
-    BIN: "#123456"
+    BIN: "#123456",
+    // Binary HTS formats
+    BAM: "#5d4037",
+    BCF: "#6d4c41",
+    CRAM: "#795548",
+    SAM: "#8d6e63",
+    // Tabular bio formats
+    VCF: "#7e57c2",
+    BED: "#26a69a",
+    GFF: "#00897b",
   };
 
   useEffect(() => {

--- a/src/components/nodes/WorkflowNode.js
+++ b/src/components/nodes/WorkflowNode.js
@@ -7,6 +7,7 @@ import { OneConnectionHandle } from './OneConnectionHandle';
 
 import { runTool, getTool } from '../../utils/toolUtils';
 import { detectDataType } from '../../utils/detectDataType';
+import { unwrap, isDataValue } from '../../utils/dataValue';
 
 export const WorkflowNode = memo(({ id, data }) => {
   const { label, paramValues, repo } = data;
@@ -69,9 +70,19 @@ export const WorkflowNode = memo(({ id, data }) => {
       inputs[targetHandle] = sourceNode.data.outputs[sourceHandle];
     });
 
-    const allInputsEmpty = Object.values(inputs).every(value =>
-      value === "" || value === undefined || value === null
-    );
+    const allInputsEmpty = Object.values(inputs).every(value => {
+      if (value === undefined || value === null || value === "") return true;
+      // Stale persistence markers (hydration failed / file imported with stripped
+      // binary) carry no data, so treat them as empty and skip the run.
+      if (value && typeof value === "object" && (value.kind === "binary-ref" || value.kind === "binary-stripped")) {
+        return true;
+      }
+      if (isDataValue(value)) {
+        if (value.kind === "binary") return !value.data || value.data.length === 0;
+        return value.data === "" || value.data === undefined || value.data === null;
+      }
+      return false;
+    });
 
     // this is to prevent the tools from running right after loading from localstorage
     if (allInputsEmpty && Object.keys(data.outputs).length === 0) return;
@@ -125,7 +136,15 @@ export const WorkflowNode = memo(({ id, data }) => {
     for (const key in data.outputs) {
       if (!outputsConnected.includes(key)) continue;
       const definedTypes = toolData.io.outputs.find(o => o.name === key).types
-      const detectedType = detectDataType(data.outputs[key], definedTypes)
+      const value = data.outputs[key];
+      let detectedType;
+      if (isDataValue(value) && value.kind === "binary") {
+        // Binary content can't be UTF-8 sniffed; trust the recipe-declared type.
+        detectedType = value.type || definedTypes?.[0] || "BIN";
+      } else {
+        const text = isDataValue(value) ? value.data : value;
+        detectedType = detectDataType(text, definedTypes);
+      }
       setInvalidOutputType(!definedTypes.includes(detectedType))
 
       outputTypes[key] = detectedType;

--- a/src/pages/WorkflowPage.js
+++ b/src/pages/WorkflowPage.js
@@ -19,6 +19,7 @@ import { loadToolIndex, loadTool } from '../utils/toolUtils';
 import ToolParameterSection from '../components/ToolParameterSection';
 import ToolOutputPanel from '../components/ToolOutputPanel'
 import { detectDataType } from '../utils/detectDataType';
+import { isDataValue, makeText } from '../utils/dataValue';
 
 const WorkflowPage = () => {
   const recipePanelRef = useRef();
@@ -81,8 +82,22 @@ const WorkflowPage = () => {
     }));
   };
 
-  const handleUpdateSelectedInputNode = (text) => {
-    updateSelectedNodeData({ outputs: { "out": text }, outputTypes: { "out": detectDataType(text) } })
+  const handleUpdateSelectedInputNode = (value) => {
+    // `value` may be a bare text string (from typing/example) OR a DataValue
+    // (from a binary upload through the file manager). Normalise: bare strings
+    // get type-detected; DataValues keep their declared type.
+    let dv;
+    let detectedType;
+    if (isDataValue(value)) {
+      dv = value;
+      detectedType = value.kind === 'binary'
+        ? (value.type || 'BIN')
+        : detectDataType(value.data ?? '');
+    } else {
+      dv = makeText(value ?? '', detectDataType(value ?? ''));
+      detectedType = dv.type;
+    }
+    updateSelectedNodeData({ outputs: { "out": dv }, outputTypes: { "out": detectedType } });
   };
 
   function handleToggleParam(name) {

--- a/src/utils/agentContract.js
+++ b/src/utils/agentContract.js
@@ -1,0 +1,75 @@
+// Build the multipart payload sent to the remote agent.
+//
+// The POST body has two kinds of fields:
+//   biochef_workflow  - JSON description of the workflow graph
+//   files[]           - actual file contents, one per InputWorkflowNode output
+//
+// Inside biochef_workflow, each input-node DataValue is replaced with a small
+// file-ref marker so the agent can match files in the multipart body back to
+// where they belong:
+//
+//   { kind: "file-ref", file: "<filename>", type: "BAM" }
+
+import { isDataValue } from "./dataValue";
+import { typeToExtensionMap } from "./getExtensionDataType";
+
+const MIME_BY_TYPE = {
+  BAM:  "application/x-bam",
+  BCF:  "application/x-bcf",
+  CRAM: "application/x-cram",
+  BIN:  "application/octet-stream",
+};
+
+export function mimeForType(type) {
+  return MIME_BY_TYPE[type] || "text/plain";
+}
+
+function filenameFor(nodeId, handle, type) {
+  // Pick the extension from the declared type so the agent (and any tools
+  // running there) can recognise the format. The previous convention used
+  // .txt for everything which broke binary handling.
+  const ext = typeToExtensionMap[type] || ".txt";
+  return `${nodeId}-${handle}${ext}`;
+}
+
+// Build the multipart payload + the workflow JSON. Returns:
+//   { workflowJSON: string, files: Array<File> }
+// Caller appends each File under "files" and the JSON under "biochef_workflow".
+export function prepareWorkflowForAgent(flow) {
+  const files = [];
+  const nodes = (flow.nodes || []).map(node => {
+    if (node.type !== "inputWorkflowNode") return node;
+    const outs = node.data?.outputs;
+    if (!outs || typeof outs !== "object") return node;
+
+    const newOuts = {};
+    for (const [handle, raw] of Object.entries(outs)) {
+      const value = raw;
+
+      if (isDataValue(value) && value.kind === "binary") {
+        const filename = filenameFor(node.id, handle, value.type || "BIN");
+        const bytes = value.data instanceof Uint8Array ? value.data : new Uint8Array(0);
+        files.push(new File([bytes], filename, { type: mimeForType(value.type) }));
+        newOuts[handle] = { kind: "file-ref", file: filename, type: value.type || "BIN" };
+      } else if (isDataValue(value) && value.kind === "text") {
+        // Text inputs go through the file slot too so tools running on the
+        // agent can read them as files just like binary inputs.
+        const filename = filenameFor(node.id, handle, value.type || "TEXT");
+        files.push(new File([value.data ?? ""], filename, { type: mimeForType(value.type) }));
+        newOuts[handle] = { kind: "file-ref", file: filename, type: value.type || "TEXT" };
+      } else if (typeof value === "string") {
+        // Bare string from older code paths; same handling as a text DV.
+        const filename = filenameFor(node.id, handle, "TEXT");
+        files.push(new File([value], filename, { type: "text/plain" }));
+        newOuts[handle] = { kind: "file-ref", file: filename, type: "TEXT" };
+      } else {
+        // Anything else (stale binary-ref/binary-stripped, undefined, ...) is
+        // missing data. Send null so the agent can detect it instead of
+        // guessing what it is.
+        newOuts[handle] = null;
+      }
+    }
+    return { ...node, data: { ...node.data, outputs: newOuts } };
+  });
+  return { workflowJSON: JSON.stringify({ ...flow, nodes }), files };
+}

--- a/src/utils/blobStore.js
+++ b/src/utils/blobStore.js
@@ -1,0 +1,81 @@
+// IndexedDB-backed blob store for binary edge values.
+//
+// localStorage can only hold strings, and JSON.stringify on a Uint8Array
+// silently drops the bytes. So instead of trying to embed binary into the
+// workflow JSON, we stash the bytes here and put a {kind:"binary-ref", type,
+// ref:"<id>"} marker in their place. The load path swaps the marker back for
+// real bytes.
+
+const DB_NAME = "biochef";
+const DB_VERSION = 1;
+const STORE = "blobs";
+
+function openDB() {
+  return new Promise((resolve, reject) => {
+    if (typeof indexedDB === "undefined") {
+      reject(new Error("IndexedDB is not available"));
+      return;
+    }
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = (e) => {
+      const db = e.target.result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        db.createObjectStore(STORE, { keyPath: "id" });
+      }
+    };
+    req.onsuccess = (e) => resolve(e.target.result);
+    req.onerror = (e) => reject(e.target.error);
+  });
+}
+
+function tx(db, mode = "readonly") {
+  return db.transaction(STORE, mode).objectStore(STORE);
+}
+
+function genId() {
+  return `b_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export async function putBlob(bytes, type = "BIN") {
+  const db = await openDB();
+  const id = genId();
+  return new Promise((resolve, reject) => {
+    const req = tx(db, "readwrite").put({ id, bytes, type, createdAt: Date.now() });
+    req.onsuccess = () => resolve(id);
+    req.onerror = (e) => reject(e.target.error);
+  });
+}
+
+export async function getBlob(id) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const req = tx(db).get(id);
+    req.onsuccess = () => resolve(req.result || null);
+    req.onerror = (e) => reject(e.target.error);
+  });
+}
+
+export async function deleteBlob(id) {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const req = tx(db, "readwrite").delete(id);
+    req.onsuccess = () => resolve();
+    req.onerror = (e) => reject(e.target.error);
+  });
+}
+
+export async function listIds() {
+  const db = await openDB();
+  return new Promise((resolve, reject) => {
+    const req = tx(db).getAllKeys();
+    req.onsuccess = () => resolve(req.result || []);
+    req.onerror = (e) => reject(e.target.error);
+  });
+}
+
+// Drop blobs whose ids are not in `keepIds`.
+export async function gcBlobs(keepIds) {
+  const ids = await listIds();
+  const keep = new Set(keepIds);
+  await Promise.all(ids.filter(id => !keep.has(id)).map(id => deleteBlob(id)));
+}

--- a/src/utils/dataValue.js
+++ b/src/utils/dataValue.js
@@ -1,0 +1,57 @@
+// Tagged-union shape for edge values. Lets the runtime tell text from binary
+// without sniffing the data. Bare strings still flow through; unwrap promotes
+// them to a text DataValue at the boundary.
+//
+//   { kind: "text",   type: "FASTA",    data: "..." }
+//   { kind: "binary", type: "BAM",      data: Uint8Array }
+
+export const BINARY_TYPES = new Set(["BAM", "BCF", "CRAM", "BIN"]);
+
+export function isBinaryType(type) {
+  return BINARY_TYPES.has(type);
+}
+
+// True if the recipe's declared type list is binary-only, i.e. the runtime
+// must read the wasm-FS file as bytes rather than UTF-8.
+export function isBinaryDeclaredTypes(declaredTypes) {
+  if (!Array.isArray(declaredTypes) || declaredTypes.length === 0) return false;
+  return declaredTypes.every(isBinaryType);
+}
+
+export function makeText(data, type = "TEXT") {
+  return { kind: "text", type, data: data ?? "" };
+}
+
+export function makeBinary(data, type = "BIN") {
+  return { kind: "binary", type, data };
+}
+
+// Accept legacy bare-string edge values; promote to a text DataValue.
+export function unwrap(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") return makeText(value);
+  if (typeof value === "object") {
+    // Stale persistence markers (hydration failed or imported file with
+    // stripped binary) carry no usable data, so return null and let the
+    // runtime skip them.
+    if (value.kind === "binary-ref" || value.kind === "binary-stripped") return null;
+    if ("kind" in value && "data" in value) return value;
+  }
+  return makeText(String(value));
+}
+
+export function isDataValue(value) {
+  return value && typeof value === "object" && "kind" in value && "data" in value;
+}
+
+// Marker that goes into workflow JSON in place of a binary DataValue while the
+// actual bytes sit in IndexedDB. The load path rehydrates these back into real
+// DataValues; without this swap, JSON.stringify would silently corrupt the
+// Uint8Array.
+export function isBinaryRef(value) {
+  return value && typeof value === "object" && value.kind === "binary-ref" && typeof value.ref === "string";
+}
+
+export function makeBinaryRef(ref, type = "BIN") {
+  return { kind: "binary-ref", type, ref };
+}

--- a/src/utils/detectDataType.js
+++ b/src/utils/detectDataType.js
@@ -1,3 +1,59 @@
+// --- Binary detection -------------------------------------------------------
+// Magic bytes for the binary HTS formats Biochef can carry through edges.
+// BGZF wraps BAM, BCF, indexed VCFs, and tabix indexes; the inner type comes
+// from filename extension or the recipe's declared output type.
+
+const BINARY_MAGIC = {
+  BGZF: [0x1f, 0x8b, 0x08, 0x04],   // BAM, BCF, .gz/.bgz, .tbi all start here
+  BAI:  [0x42, 0x41, 0x49, 0x01],   // "BAI\x01"
+  CSI:  [0x43, 0x53, 0x49, 0x01],   // "CSI\x01"
+  CRAM: [0x43, 0x52, 0x41, 0x4d],   // "CRAM"
+  MMI:  [0x4d, 0x4d, 0x49, 0x02],   // "MMI\x02"
+};
+
+function startsWith(bytes, magic) {
+  if (!bytes || bytes.length < magic.length) return false;
+  for (let i = 0; i < magic.length; i++) if (bytes[i] !== magic[i]) return false;
+  return true;
+}
+
+const BINARY_EXTENSIONS = {
+  ".bam": "BAM",
+  ".bcf": "BCF",
+  ".cram": "CRAM",
+  ".bai": "BIN",
+  ".csi": "BIN",
+  ".tbi": "BIN",
+  ".gzi": "BIN",
+  ".mmi": "BIN",
+  ".fai": "BIN",
+  ".gz":  "BIN",
+  ".bgz": "BIN",
+};
+
+export function detectBinaryType(bytes, fileName = "") {
+  // Extension wins when present, since the recipe-declared type is more
+  // reliable than sniffing the bytes.
+  const lower = fileName.toLowerCase();
+  for (const [ext, type] of Object.entries(BINARY_EXTENSIONS)) {
+    if (lower.endsWith(ext)) return type;
+  }
+  // Otherwise sniff magic bytes.
+  if (startsWith(bytes, BINARY_MAGIC.BAI))  return "BIN";
+  if (startsWith(bytes, BINARY_MAGIC.CSI))  return "BIN";
+  if (startsWith(bytes, BINARY_MAGIC.CRAM)) return "CRAM";
+  if (startsWith(bytes, BINARY_MAGIC.MMI))  return "BIN";
+  if (startsWith(bytes, BINARY_MAGIC.BGZF)) return "BIN";  // could be BAM/BCF/TBI; caller must refine
+  return "BIN";
+}
+
+export function isLikelyBinaryFile(fileName = "") {
+  const lower = fileName.toLowerCase();
+  return Object.keys(BINARY_EXTENSIONS).some(ext => lower.endsWith(ext));
+}
+
+// --- Text detection (existing) ----------------------------------------------
+
 function validateFasta(content) {
   const lines = content?.trim().split('\n');
   if (!lines || lines[0][0] !== '>') return false;

--- a/src/utils/fileProcessor.js
+++ b/src/utils/fileProcessor.js
@@ -1,7 +1,14 @@
-import { detectDataType } from './detectDataType';
+import { detectDataType, detectBinaryType, isLikelyBinaryFile } from './detectDataType';
+import { makeText, makeBinary } from './dataValue';
 
 // Define acceptable file extensions
-export const acceptableExtensions = ['.fasta', '.fa', '.fastq', '.fq', '.pos', '.svg', '.txt', '.num'];
+export const acceptableExtensions = [
+  // text
+  '.fasta', '.fa', '.fastq', '.fq', '.pos', '.svg', '.txt', '.num',
+  '.vcf', '.bed', '.gff', '.gtf', '.sam', '.json', '.tsv',
+  // binary (read as ArrayBuffer; emitted as DataValue{kind:"binary"})
+  '.bam', '.bcf', '.cram', '.bai', '.csi', '.tbi', '.gzi', '.mmi', '.fai', '.gz', '.bgz',
+];
 
 const readFirstNLines = (file, maxLines = 100) => {
     return new Promise((resolve, reject) => {
@@ -78,6 +85,34 @@ export const processFile = async (file, validateData, showNotification) => {
         return null;
     }
 
+    // Binary path: read as ArrayBuffer, emit DataValue{kind:"binary"}.
+    if (isLikelyBinaryFile(file.name)) {
+        try {
+            const reader = new FileReader();
+            const buf = await new Promise((resolve, reject) => {
+                reader.onload = (e) => resolve(e.target.result);
+                reader.onerror = () => reject(new Error('Error reading file'));
+                reader.readAsArrayBuffer(file);
+            });
+            const bytes = new Uint8Array(buf);
+            const detectedType = detectBinaryType(bytes, file.name);
+            return {
+                id: `${file.name}-${Date.now()}`,
+                name: file.name,
+                type: "file",
+                fileType: detectedType,
+                content: makeBinary(bytes, detectedType),
+                size: file.size,
+                lastModified: new Date(file.lastModified),
+                relativePath: '',
+            };
+        } catch (error) {
+            showNotification(`Failed to read file: ${file.name}`, 'error');
+            return null;
+        }
+    }
+
+    // Text path: existing behaviour, with size cap and partial-read warning.
     const fileSizeLimit = 1 * 1024 * 1024; // 1MB limit
     const isPartial = file.size > fileSizeLimit;
 
@@ -88,7 +123,6 @@ export const processFile = async (file, validateData, showNotification) => {
             showNotification(`The file ${file.name} is too large. Only the first 10000 lines will be loaded.`, 'warning');
             content = await readFirstNLines(file, 10000);
         } else {
-            // For smaller files, read the entire content
             const reader = new FileReader();
             content = await new Promise((resolve, reject) => {
                 reader.onload = (e) => resolve(e.target.result);
@@ -109,7 +143,7 @@ export const processFile = async (file, validateData, showNotification) => {
             name: file.name,
             type: "file",
             fileType: detectedType,
-            content,
+            content: makeText(content, detectedType),
             size: file.size,
             lastModified: new Date(file.lastModified),
             relativePath: '',
@@ -118,4 +152,4 @@ export const processFile = async (file, validateData, showNotification) => {
         showNotification(`Failed to read file: ${file.name}`, 'error');
         return null;
     }
-}; 
+};

--- a/src/utils/getExtensionDataType.js
+++ b/src/utils/getExtensionDataType.js
@@ -14,6 +14,15 @@ export const typeToExtensionMap = {
     'BIN': '.bin',
     'UNKNOWN': '.txt',
     'Group': '.txt',
+    // Tabular bio formats
+    'VCF': '.vcf',
+    'BED': '.bed',
+    'GFF': '.gff',
+    'SAM': '.sam',
+    // Binary HTS formats
+    'BAM': '.bam',
+    'BCF': '.bcf',
+    'CRAM': '.cram',
 };
 
 /**

--- a/src/utils/importRecipeConfigFile.js
+++ b/src/utils/importRecipeConfigFile.js
@@ -48,16 +48,24 @@ export const importRecipeConfigFile = (
         try {
             setTabIndex(1);
 
-            const processedFiles = files.map(file => ({
-                id: `${file.name}-${Date.now()}`,
-                name: file.name,
-                type: "file",
-                fileType: file.fileType,
-                content: file.content,
-                size: file.content.length,
-                lastModified: new Date(),
-                relativePath: file.relativePath || file.name
-            }));
+            const processedFiles = files.map(file => {
+                // file.content is either a bare string (older code path) or a
+                // DataValue. Pull the size off the right place.
+                const c = file.content;
+                const size = (c && typeof c === 'object' && 'data' in c)
+                    ? (c.data?.length ?? 0)
+                    : (c?.length ?? 0);
+                return {
+                    id: `${file.name}-${Date.now()}`,
+                    name: file.name,
+                    type: "file",
+                    fileType: file.fileType,
+                    content: file.content,
+                    size,
+                    lastModified: new Date(),
+                    relativePath: file.relativePath || file.name
+                };
+            });
 
             const newFilesTree = [];
             processedFiles.forEach(file => {

--- a/src/utils/persistBinary.js
+++ b/src/utils/persistBinary.js
@@ -1,0 +1,97 @@
+// Walk a workflow object and swap binary DataValues out for ref markers,
+// storing the actual bytes in IndexedDB. localStorage just holds the JSON
+// with refs; on load we reverse the swap.
+
+import { isDataValue, isBinaryRef, makeBinary, makeBinaryRef } from "./dataValue";
+import { putBlob, getBlob, gcBlobs } from "./blobStore";
+
+// Walk node.data.outputs across all nodes, replace binary DataValues with refs.
+// Returns the modified `flow` (mutated copy of nodes) plus the set of refs in use.
+export async function externalizeBinaryOutputs(flow) {
+  const usedRefs = [];
+  const nodes = await Promise.all((flow.nodes || []).map(async (node) => {
+    const outs = node.data?.outputs;
+    if (!outs || typeof outs !== "object") return node;
+    const newOuts = {};
+    for (const [k, v] of Object.entries(outs)) {
+      // Externalise every binary DataValue, even empty ones. A raw Uint8Array
+      // survives JSON.stringify as {} (an indexed object) and on reload that
+      // would break new Blob([{}]) at mount time.
+      if (isDataValue(v) && v.kind === "binary") {
+        const bytes = v.data instanceof Uint8Array ? v.data : new Uint8Array(0);
+        const id = await putBlob(bytes, v.type);
+        usedRefs.push(id);
+        newOuts[k] = makeBinaryRef(id, v.type);
+      } else {
+        newOuts[k] = v;
+      }
+    }
+    return { ...node, data: { ...node.data, outputs: newOuts } };
+  }));
+  return { flow: { ...flow, nodes }, usedRefs };
+}
+
+// Reverse the swap: walk loaded flow, find {kind:"binary-ref"} markers, fetch
+// bytes from IndexedDB and rebuild DataValues.
+export async function hydrateBinaryOutputs(flow) {
+  const nodes = await Promise.all((flow.nodes || []).map(async (node) => {
+    const outs = node.data?.outputs;
+    if (!outs || typeof outs !== "object") return node;
+    const newOuts = {};
+    for (const [k, v] of Object.entries(outs)) {
+      if (isBinaryRef(v)) {
+        const blob = await getBlob(v.ref);
+        if (blob && blob.bytes) {
+          newOuts[k] = makeBinary(blob.bytes, v.type || blob.type || "BIN");
+        } else {
+          // Ref dangling (blob deleted/missing); fall back to empty binary.
+          newOuts[k] = makeBinary(new Uint8Array(0), v.type || "BIN");
+        }
+      } else {
+        newOuts[k] = v;
+      }
+    }
+    return { ...node, data: { ...node.data, outputs: newOuts } };
+  }));
+  return { ...flow, nodes };
+}
+
+// Used by the workflow-file export path. Drops binary bytes entirely and
+// leaves a tiny placeholder so the workflow structure stays portable. Inlining
+// hundreds of MB of binary into a JSON file is rarely what the user wants and
+// the bytes would be unverifiable on another machine anyway.
+export function stripBinaryForExport(flow) {
+  let strippedAny = false;
+  const nodes = (flow.nodes || []).map(node => {
+    const outs = node.data?.outputs;
+    if (!outs || typeof outs !== "object") return node;
+    const newOuts = {};
+    for (const [k, v] of Object.entries(outs)) {
+      if (isDataValue(v) && v.kind === "binary") {
+        strippedAny = true;
+        newOuts[k] = { kind: "binary-stripped", type: v.type || "BIN", note: "binary content removed for export" };
+      } else if (isBinaryRef(v)) {
+        strippedAny = true;
+        newOuts[k] = { kind: "binary-stripped", type: v.type || "BIN", note: "binary content removed for export" };
+      } else {
+        newOuts[k] = v;
+      }
+    }
+    return { ...node, data: { ...node.data, outputs: newOuts } };
+  });
+  return { flow: { ...flow, nodes }, strippedAny };
+}
+
+// GC: drop IndexedDB blobs whose ids aren't referenced by any node in the
+// currently-loaded flow. Call after every save.
+export async function gcOrphans(flow) {
+  const refs = [];
+  for (const node of (flow.nodes || [])) {
+    const outs = node.data?.outputs;
+    if (!outs) continue;
+    for (const v of Object.values(outs)) {
+      if (isBinaryRef(v)) refs.push(v.ref);
+    }
+  }
+  await gcBlobs(refs);
+}

--- a/src/utils/toolUtils.js
+++ b/src/utils/toolUtils.js
@@ -1,5 +1,6 @@
 import Aioli from "./aioli-custom/aioli"
 import logger from "./logger";
+import { unwrap, makeText, makeBinary, isBinaryDeclaredTypes } from "./dataValue";
 
 const toolMap = new Map();
 const blobMap = new Map();
@@ -268,15 +269,21 @@ export async function runTool(
 
       const inputConfig = toolConfig.io.inputs.find(i => i.name === inputName);
       const fileName = `${inputName}.txt`
+      const dv = unwrap(inputValue);
+      if (!dv) continue;
 
       if (inputConfig.mode == "file") {
-        await CLI.mount({ name: fileName, data: inputValue })
+        // Binary edge values mount as a Blob so aioli writes the bytes
+        // straight into the wasm filesystem without trying to UTF-8 decode.
+        const payload = dv.kind === "binary" ? new Blob([dv.data]) : dv.data;
+        await CLI.mount({ name: fileName, data: payload })
         if (inputConfig.flag) args.push(inputConfig.flag);
         args.push(fileName)
       }
       else if (inputConfig.mode == "stdin") {
         // TODO: check if only one has stdin? or maybe add them?
-        CLI.stdin = inputValue;
+        // stdin is text-only at the aioli boundary; binary stdin is uncommon.
+        CLI.stdin = dv.kind === "binary" ? new TextDecoder("latin1").decode(dv.data) : dv.data;
       }
     };
 
@@ -311,18 +318,30 @@ export async function runTool(
     const ignoreList = [".", ".."];
     const outputs = {};
     for (const output of toolConfig.io.outputs) {
+      const declaredType = output.types?.[0] || "TEXT";
+      const isBinary = isBinaryDeclaredTypes(output.types);
+
       if (output.mode === "stdout") {
-        outputs[output.name] = cli_result.stdout; // TODO: stderr
+        // aioli's exec captures stdout as a UTF-8 string. Binary stdout is
+        // therefore lossy; recipes that produce binary should declare mode=file.
+        outputs[output.name] = makeText(cli_result.stdout, declaredType);
       }
       else if (output.mode === "file") {
-        let fileData = "";
-        if (output.filename) {
-          fileData = await CLI.cat(output.filename);
+        const path = output.filename || (output.name + ".txt");
+        if (isBinary) {
+          // ls() on a file returns its stat (with .size); read() returns Uint8Array.
+          let size = 0;
+          try { const stat = await CLI.ls(path); size = stat?.size ?? 0; } catch { size = 0; }
+          if (size > 0) {
+            const bytes = await CLI.read({ path, length: size, flag: "r" });
+            outputs[output.name] = makeBinary(bytes, declaredType);
+          } else {
+            outputs[output.name] = makeBinary(new Uint8Array(0), declaredType);
+          }
+        } else {
+          const fileData = await CLI.cat(path);
+          outputs[output.name] = makeText(fileData, declaredType);
         }
-        else {
-          fileData = await CLI.cat(output.name + ".txt");
-        }
-        outputs[output.name] = fileData;
       }
     }
 


### PR DESCRIPTION
This PR teaches the frontend to carry binary bytes through workflow edges instead of just UTF-8 text. The motivation is that bcftools, samtools, htslib, minimap2 and similar tools often produce or consume BAM, BCF, CRAM, BGZF, and various index files. Until now the runtime treated every edge value as a string and silently truncated those binary streams at the first null byte, so a chain like sort then index then merge could not run end to end.

  **The work is split into five logical pieces.**

-   The first piece introduces a small tagged wrapper called DataValue. Every edge value is now either a text DataValue or a binary DataValue, with the recipe declared type carried alongside the data. The runtime mounts text inputs as before, but mounts binary inputs as Blobs through aioli, and reads binary outputs back as Uint8Array using ls plus read instead of cat. Bare strings still work everywhere because the unwrap helper promotes them to text DataValues on the boundary, so existing recipes need no changes.
-   The second piece updates the upload paths and the rendering. File uploads switch to readAsArrayBuffer when the extension matches a known binary format (bam, bcf, cram, bai, csi, tbi, gzi, mmi, fai, gz, bgz). Binary outputs render as a placeholder in the textarea ("binary BAM, N bytes, use Save to download") and the Save button produces a blob with the correct MIME and extension. The detection module gained a magic byte sniff for BGZF, BAI, CSI, CRAM, and MMI. Edge colors and the type to extension map were extended to cover BAM, BCF, CRAM, SAM, VCF, BED, GFF.
-   The third piece deals with persistence. JSON.stringify silently corrupts a Uint8Array by serializing it as an indexed object, so saving a workflow with a binary input would lose the bytes on reload. The new blobStore module wraps IndexedDB with put, get, delete, list, and gc helpers. The new persistBinary module walks a workflow and, before saving, swaps every binary DataValue out for a small marker that just carries an id, putting the bytes themselves into IndexedDB. On load, those markers are hydrated back into real DataValues. Orphan blobs from cancelled saves are garbage collected. Workflow file export takes a different path, since embedding a hundred megabyte BAM into a portable JSON would be wrong; binary inputs are stripped with a notification and the user is expected to re-upload them on the receiving side. Import scrubs both stripped markers and ref markers, since refs from another machine point at blobs that do not exist locally.
-   The fourth piece updates the remote agent contract. The runWorkflowAgent function now uses multipart form-data with proper MIME types per file (application x-bam, application x-bcf, application octet-stream, text plain), proper extensions in the filenames (no more hardcoded .txt), and a clean separation between the workflow JSON and the file slots. Each input node output becomes a file in the multipart body and a small file-ref marker in the JSON. Existing local agent servers will need a small update to match the new filename and MIME conventions, but the endpoint is dev-only so there is no production impact.
-   The fifth piece is testing. The production webpack build compiles cleanly. Ninety one automated tests pass across three suites: forty nine integration tests covering the DataValue helpers, magic byte detection, strip for export, prepareWorkflowForAgent, and the edge value lifecycle; thirty two adversarial edge cases (falsy unwrap inputs, truncated magic bytes, uppercase extensions, multi-dot paths, ten megabyte Uint8Array round trip, empty binary in the agent path, JSON round trip with high byte UTF-8 characters); and ten IndexedDB round trip tests using fake-indexeddb, including the empty Uint8Array case  and the dangling-ref fallback.

A few honest caveats remain. Aioli's exec returns process stdout as a UTF-8 string, which is lossy for binary, so any recipe that declares a binary output with mode stdout will still corrupt those bytes; the workaround is to declare such outputs as mode file with an explicit -o flag, which is what samtools merge, samtools index, and htslib bgzip already do. The agent receive path is still text only; if the agent ever returns binary outputs that would need a separate multipart channel from agent to frontend, but no such recipe exists today. And while the helper logic is well covered by Node tests, the actual React Flow plus IndexedDB plus FileReader interactions in a browser still need a dev session to exercise; if anything surfaces there it will be small and surgical.

  Total change is around four hundred and thirty lines added and a hundred deleted across eighteen files, with four new files in src utils.

  This PR also unblocks the htslib recipe (bgzip and tabix only become useful once binary edges exist) and makes the existing bcftools, samtools, bedtools, bowtie2, and minimap2 recipes more useful end to end.