### PR TITLE
Development docker compose

### DIFF
--- a/Dockerfile.hub.dev
+++ b/Dockerfile.hub.dev
@@ -1,0 +1,51 @@
+FROM ubuntu:24.04
+
+ARG EMSDK_VERSION=4.0.18
+ARG BIOCHEF_HUB_REPOSITORY=https://github.com/ieeta-pt/biochef-hub.git
+ARG BIOCHEF_HUB_REF=master
+
+ENV EMSDK=/opt/emsdk \
+    EMSDK_VERSION=${EMSDK_VERSION} \
+    VIRTUAL_ENV=/opt/biochef-venv \
+    PATH=/opt/biochef-venv/bin:/opt/emsdk:/opt/emsdk/upstream/emscripten:${PATH}
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        autopoint \
+        bison \
+        build-essential \
+        ca-certificates \
+        cmake \
+        curl \
+        git \
+        gettext \
+        gperf \
+        help2man \
+        pkg-config \
+        python3 \
+        python3-pip \
+        python3-venv \
+        rsync \
+        sudo \
+        texinfo \
+        wget
+
+RUN python3 -m venv "$VIRTUAL_ENV" \
+    && pip install --no-cache-dir --upgrade pip
+
+RUN git clone https://github.com/emscripten-core/emsdk.git "$EMSDK" \
+    && "$EMSDK/emsdk" install "$EMSDK_VERSION" \
+    && "$EMSDK/emsdk" activate "$EMSDK_VERSION" \
+    && printf '%s\n' \
+        'export EMSDK_QUIET=1' \
+        '. /opt/emsdk/emsdk_env.sh >/dev/null' \
+        "export EMSDK_VERSION=$EMSDK_VERSION" \
+        > /etc/profile.d/emsdk.sh
+
+RUN git clone "$BIOCHEF_HUB_REPOSITORY" /hub \
+    && git -C /hub checkout "$BIOCHEF_HUB_REF" \
+    && pip install --no-cache-dir -r /hub/hub/requirements.txt
+
+WORKDIR /work

--- a/Dockerfile.hub.dev
+++ b/Dockerfile.hub.dev
@@ -9,6 +9,7 @@ ENV EMSDK=/opt/emsdk \
     VIRTUAL_ENV=/opt/biochef-venv \
     PATH=/opt/biochef-venv/bin:/opt/emsdk:/opt/emsdk/upstream/emscripten:${PATH}
 
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         autoconf \
@@ -31,7 +32,7 @@ RUN apt-get update \
         sudo \
         texinfo \
         wget
-
+        
 RUN python3 -m venv "$VIRTUAL_ENV" \
     && pip install --no-cache-dir --upgrade pip
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,5 +19,24 @@ services:
       - biochef-registry:/var/lib/registry
       - ./registry-config.yml:/etc/docker/registry/config.yml:ro
 
+  hub:
+    profiles:
+      - tools
+    image: ${BIOCHEF_HUB_IMAGE:-biochef-hub-dev:local}
+    build:
+      context: .
+      dockerfile: Dockerfile.hub.dev
+      args:
+        BIOCHEF_HUB_REPOSITORY: ${BIOCHEF_HUB_REPOSITORY:-https://github.com/ieeta-pt/biochef-hub.git}
+        BIOCHEF_HUB_REF: ${BIOCHEF_HUB_REF:-master}
+    working_dir: /work
+    volumes:
+      - ${BIOCHEF_RECIPES_ROOT:-.}:/recipes:ro
+      - biochef-hub-work:/work
+    network_mode: service:registry
+    depends_on:
+      - registry
+
 volumes:
   biochef-registry:
+  biochef-hub-work:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,7 +16,8 @@ services:
     ports:
       - "5000:5000"
     volumes:
-      - registry-data:/var/lib/registry
+      - biochef-registry:/var/lib/registry
+      - ./registry-config.yml:/etc/docker/registry/config.yml:ro
 
 volumes:
-  registry-data:
+  biochef-registry:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,22 @@
+services:
+  frontend:
+    image: node:26-alpine
+    working_dir: /app
+    volumes:
+      - .:/app
+      - /app/node_modules
+    env_file:
+      - example.env
+    command: sh -c "npm install && npm start"
+    ports:
+      - "8082:8082"
+
+  registry:
+    image: registry:2
+    ports:
+      - "5000:5000"
+    volumes:
+      - registry-data:/var/lib/registry
+
+volumes:
+  registry-data:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -33,6 +33,8 @@ services:
     volumes:
       - ${BIOCHEF_RECIPES_ROOT:-.}:/recipes:ro
       - biochef-hub-work:/work
+      # Share the host Docker daemon with the container so it can use the biowasm docker image.
+      - /var/run/docker.sock:/var/run/docker.sock
     network_mode: service:registry
     depends_on:
       - registry

--- a/example.env
+++ b/example.env
@@ -1,4 +1,11 @@
+# url where the website will fetch the tools
+# use http://localhost:5000 if using the docker compose 
 REGISTRY_URL=http://localhost:5000
-REPO_OWNER=Biochef
-REGISTRY_USERNAME=Biochef
-REGISTRY_PASSWORD=ghp_1234567890abcdefghijklmnopqrstuvwxYZ12
+
+# owner of the github repository
+# this is only used if using ghcr
+REPO_OWNER=
+
+# credentials for the registry
+REGISTRY_USERNAME=
+REGISTRY_PASSWORD=

--- a/registry-config.yml
+++ b/registry-config.yml
@@ -1,0 +1,19 @@
+version: 0.1
+log:
+  fields:
+    service: registry
+storage:
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /var/lib/registry
+http:
+  addr: :5000
+  headers:
+    Access-Control-Allow-Origin: ["*"]
+    Access-Control-Allow-Headers: ["Authorization", "X-Requested-With", "Content-Type"]
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3

--- a/scripts/publish-local-recipe.sh
+++ b/scripts/publish-local-recipe.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 [--rebuild] [--hub <hub-dir>] --recipe <biochef.yaml> [biochef.yaml ...]" >&2
+}
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+frontend_dir=$(dirname -- "$script_dir")
+recipe_inputs=()
+rebuild=false
+hub_dir=
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --recipe|--recipes)
+      shift
+      if [[ $# -eq 0 || "$1" == -* ]]; then
+        echo "Missing recipe path after --recipe/--recipes" >&2
+        usage
+        exit 2
+      fi
+      while [[ $# -gt 0 && "$1" != -* ]]; do
+        recipe_inputs+=("$1")
+        shift
+      done
+      ;;
+    --rebuild)
+      rebuild=true
+      shift
+      ;;
+    --hub)
+      hub_dir=${2:-}
+      if [[ -z "$hub_dir" ]]; then
+        echo "Missing hub directory after --hub" >&2
+        usage
+        exit 2
+      fi
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    -* )
+      echo "Unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+    *)
+      recipe_inputs+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ ${#recipe_inputs[@]} -eq 0 ]]; then
+  usage
+  exit 2
+fi
+
+recipe_paths=()
+recipe_dirs=()
+for recipe_input in "${recipe_inputs[@]}"; do
+  if [[ -f "$recipe_input" ]]; then
+    recipe_dir=$(CDPATH= cd -- "$(dirname -- "$recipe_input")" && pwd -P)
+    recipe_path="$recipe_dir/$(basename -- "$recipe_input")"
+  else
+    echo "Recipe not found: $recipe_input" >&2
+    exit 2
+  fi
+
+  if [[ "$(basename -- "$recipe_path")" != biochef.yaml ]]; then
+    echo "Recipe file must be named biochef.yaml: $recipe_path" >&2
+    exit 2
+  fi
+
+  recipe_paths+=("$recipe_path")
+  recipe_dirs+=("$recipe_dir")
+done
+
+recipes_root=${recipe_dirs[0]}
+for recipe_dir in "${recipe_dirs[@]}"; do
+  while [[ "$recipe_dir" != "$recipes_root" && "$recipe_dir" != "$recipes_root"/* ]]; do
+    recipes_root=$(dirname -- "$recipes_root")
+  done
+done
+
+container_recipes=()
+for recipe_path in "${recipe_paths[@]}"; do
+  relative_path=${recipe_path#"$recipes_root"/}
+  container_recipes+=("/recipes/$relative_path")
+done
+
+run_args=(run --rm)
+if [[ -n "$hub_dir" ]]; then
+  if [[ -d "$hub_dir" ]]; then
+    hub_dir=$(CDPATH= cd -- "$hub_dir" && pwd -P)
+  else
+    echo "Hub directory not found: $hub_dir" >&2
+    exit 2
+  fi
+
+  if [[ ! -f "$hub_dir/hub/hub.py" ]]; then
+    echo "Hub directory must contain hub/hub.py: $hub_dir" >&2
+    exit 2
+  fi
+
+  run_args+=(--volume "$hub_dir:/hub:ro" --env BIOCHEF_INSTALL_LOCAL_HUB_DEPS=1)
+fi
+
+export BIOCHEF_RECIPES_ROOT="$recipes_root"
+export BIOCHEF_HUB_IMAGE=${BIOCHEF_HUB_IMAGE:-biochef-hub-dev:local}
+
+compose=(docker compose -f "$frontend_dir/docker-compose.dev.yml" --profile tools)
+
+if [[ "$rebuild" == true ]] || ! docker image inspect "$BIOCHEF_HUB_IMAGE" >/dev/null 2>&1; then
+  "${compose[@]}" build hub
+fi
+
+"${compose[@]}" "${run_args[@]}" \
+  --entrypoint bash \
+  hub -lc '
+    set -euo pipefail
+    if [[ "${BIOCHEF_INSTALL_LOCAL_HUB_DEPS:-0}" == "1" ]]; then
+      pip install --no-cache-dir -r /hub/hub/requirements.txt
+    fi
+    python3 /hub/hub/hub.py validate "$@"
+    python3 /hub/hub/hub.py build
+    python3 /hub/hub/hub.py publish --registry localhost:5000
+  ' bash "${container_recipes[@]}"


### PR DESCRIPTION
Running the platform currently requires running multiple parts individually. This pull request tries to fix this by adding a docker compose that will run the frontend together with running the registry image. Currently it doesn't populate the registry and requires the user to manually run each command in the hub to add a new recipe. Simplifying this will probably require add either a script or dockerfile to the hub that will take the path to a recipe and run the entire pipeline, just like the github workflows does.