### PR TITLE
Honour the filename declared on a recipe input

### DIFF
--- a/src/utils/toolUtils.js
+++ b/src/utils/toolUtils.js
@@ -243,6 +243,40 @@ async function getToolBlobs(toolName) {
   return [wasmBlob, jsBlob]
 }
 
+// aioli mounts every file flat into the shared data directory and symlinks it
+// from the working directory, so a mount name must be a single path component.
+// A name containing a separator makes the symlink step throw ENOENT and takes
+// down the whole worker.
+function isSafeMountName(name) {
+  if (typeof name !== "string") return false
+  if (name.length === 0 || name.length > 255) return false
+  if (name.includes("/") || name.includes("\\") || name.includes("\0")) return false
+  if (name === "." || name === "..") return false
+
+  return true
+}
+
+// Resolve the name an input file is mounted under.
+//
+// Recipes may set io.inputs[].filename when a tool dispatches on the file
+// extension, or needs to locate a sibling file by name. The declared name is
+// appended to the per-invocation prefix rather than replacing it, so the
+// extension and any sibling relationship survive while names stay unique
+// between nodes. Inputs that declare nothing keep the previous name.
+export function resolveInputFileName(uniqueId, inputDefinition) {
+  const fallback = `input-${uniqueId}-${inputDefinition.name}.txt`
+  const declared = inputDefinition.filename
+
+  if (declared === undefined) return fallback
+
+  if (!isSafeMountName(declared)) {
+    logger.warn(`[resolveInputFileName] Ignoring unusable filename "${declared}" on input "${inputDefinition.name}"`)
+    return fallback
+  }
+
+  return `input-${uniqueId}-${declared}`
+}
+
 async function aioliReadFileHelper(CLI, fileName) {
   const stat = await CLI.ls(fileName)
 
@@ -348,7 +382,7 @@ export async function runTools(
 
       if (mode === "text") {
         if (inputDefinition.mode === "file") {
-          inputFileName = `input-${invocation.uniqueId}-${inputDefinition.name}.txt`
+          inputFileName = resolveInputFileName(invocation.uniqueId, inputDefinition)
           const fileContent = value.kind === "binary" ? new Blob([value.data]) : value.data;
           await CLI.mount({ name: inputFileName, data: fileContent })
         }
@@ -358,11 +392,36 @@ export async function runTools(
       }
       else if (mode === "output") {
         const [source, sourceOutput] = value
-        inputFileName = `${source}-${sourceOutput}.txt`
+        const producedFileName = `${source}-${sourceOutput}.txt`
+        inputFileName = producedFileName
 
         if (inputDefinition.mode === "stdin") {
-          const fileData = await aioliReadFileHelper(CLI, inputFileName)
-          stdinValue = fileData.data
+          // Always read the name the producing node actually wrote. Renaming
+          // before this point would read a file that does not exist yet.
+          const fileData = await aioliReadFileHelper(CLI, producedFileName)
+
+          if (!fileData) {
+            logger.warn(`[runTools] Input "${inputDefinition.name}" expected "${producedFileName}" from an earlier step, which was not produced`)
+          }
+
+          stdinValue = fileData?.data
+        }
+        else if (inputDefinition.mode === "file" && inputDefinition.filename !== undefined) {
+          // The producing node named the file after its own output. Re-mount it
+          // under the name this tool expects to see.
+          const desiredFileName = resolveInputFileName(invocation.uniqueId, inputDefinition)
+
+          if (desiredFileName !== producedFileName) {
+            const fileData = await aioliReadFileHelper(CLI, producedFileName)
+
+            if (fileData) {
+              await CLI.mount({
+                name: desiredFileName,
+                data: fileData.kind === "binary" ? new Blob([fileData.data]) : fileData.data,
+              })
+              inputFileName = desiredFileName
+            }
+          }
         }
       }
 


### PR DESCRIPTION
> **Merge order.** ieeta-pt/Biochef#92 is stacked on this branch — merge this one first. #92 adds a `sidecar` input mode and is what finally unblocks bcftools merge/isec/consensus, which this PR explicitly says it does *not* unblock on its own. It pairs with ieeta-pt/biochef-hub#26 on the schema side.

## Summary

`io.inputs[].filename` has been part of the recipe schema for a while — `hub/validate/validate.py` accepts it and `hub/builders/builder.py` copies the operation into the published bundle verbatim — but the frontend never read it. Every file input was mounted as `input-<nodeId>-<inputName>.txt` regardless of what the recipe asked for.

Two consequences: tools that dispatch on the file extension get handed a `.txt` and misparse it, and there is no way to place a file where a tool expects to find it by name.

This reads the key. The declared name is **appended to the per-invocation prefix** rather than replacing it, so names stay unique between nodes while the extension and any sibling relationship survive:

| declared | mounted as |
|---|---|
| *(nothing)* | `input-<nodeId>-<inputName>.txt` — unchanged |
| `reads.fasta` | `input-<nodeId>-reads.fasta` |
| `a.vcf.gz` | `input-<nodeId>-a.vcf.gz` |
| `a.vcf.gz.csi` | `input-<nodeId>-a.vcf.gz.csi` |

Both the uploaded-file path and the piped-from-upstream path resolve through the same helper, so a workflow that mixes an upload with a piped file still produces names that match each other. An earlier draft of this used a different scheme per path; that silently breaks the mixed case, which is the most common shape.

## No recipe changes behaviour

I checked this rather than assuming it. Across **79 refs of biochef-recipes — 1,187 `biochef.yaml` files, 10,646 operations, 14,025 input definitions**, plus the working tree, the complete set of keys ever used on an input is:

```
['flag', 'mode', 'name', 'types']
```

`filename` appears **0 times on an input** (and 866 times on outputs, which confirms the scan reads the right nodes). Running the new resolver over all 14,025 gives **0 changed names**. The new branch is unreachable until a recipe opts in.

## Validation of declared names

aioli mounts files flat into the shared data directory and then symlinks each into the working directory. Only the `unlink` before that symlink is wrapped in `try/catch`, so a name containing a separator throws `ENOENT` and takes down the worker. Declared names are therefore rejected — with a warning, falling back to the previous name — when empty, longer than 255 characters, containing `/`, `\` or NUL, or equal to `.` or `..`.

## Incidental fix

The stdin-from-upstream branch dereferenced `aioliReadFileHelper(...)` without checking it. That helper returns `undefined` when the file does not exist, and since there is no `try/catch` around the invocation loop the resulting `TypeError` escaped `runTools` and aborted every remaining node — leaving the UI with all downstream nodes stuck spinning, because they had already been marked running. It now warns and continues. This is pre-existing and unrelated to the rename, but it sits in the lines being touched and is two characters to fix.

## What this does and does not unblock

**Does:** spoa (biochef-recipes #51), whose stated blocker is *"problems with tool requiring correct file extensions"* — a single file input, extension-sniffed, no sidecar.

**Does not:** bcftools `merge` / `isec` / `consensus` / `annotate -a`. Those need a sidecar index mounted *without* being emitted to argv, and `toolUtils.js` emits every `mode: file` input onto the command line unconditionally — flagged, or positional if it has no flag. A `.csi` declared as an extra input would arrive as a stray positional argument. Making those work needs a mount-only input mode in both this file and `hub/validate/validate.py`, which restricts `mode` to `file|stdin`. That is a separate change and a separate hub PR.

## Verification

- **Corpus check** — the 14,025-input scan above, 0 names changed.
- **Behaviour** — the declared, sibling-pair, and each rejection case asserted against the resolver.
- **Build** — `npm run build`: `webpack 5.106.2 compiled successfully`.

No automated tests were run, because the repo has no test script and no jest/vitest, and no workflow runs on a PR here. The corpus check is the substantive regression evidence: the changed path cannot execute for any recipe that exists today.

## Compatibility with branches that could land

Checked against every branch in the repo. Only two are open: **#90 aioli-vendored** touches this file at line 1 (the import) and end-of-file (`getToolRuntimes`); **#89 docker** does not touch it at all. This change sits in the input-preparation loop, so there is no overlap with either. #90 also keeps the same `Aioli` class and `CLI.mount({name, data})` call shape, so the change is compatible with the vendored aioli as well as the current one.

Worth flagging for sequencing: the binary-I/O work (DataValue, magic-byte detection, IndexedDB) rewrites the read-and-remount block a little further down this same function. If that lands after this, expect a small conflict in `toolUtils.js` around the output-harvest lines.



---

### Merge order

#92 is stacked on this one and should merge after it.

`src/utils/toolUtils.js` is where five open branches meet: #91, #92, #93, this one, and WildBunnie's `aioli-vendored` (#90). They all conflict there pairwise, so the order matters more than usual.
