### PR TITLE
Mount sidecar inputs without placing them on the command line

### DIFF
--- a/src/utils/toolUtils.js
+++ b/src/utils/toolUtils.js
@@ -380,8 +380,14 @@ export async function runTools(
       let inputFileName = undefined
       let stdinValue = undefined
 
+      // A sidecar is placed in the filesystem exactly like a file input, but is
+      // never put on the command line. Tools locate it by name instead: htslib
+      // looks for an index at <datafile>.csi, so the file has to be present
+      // under that name and absent from the arguments.
+      const isMountedInput = inputDefinition.mode === "file" || inputDefinition.mode === "sidecar"
+
       if (mode === "text") {
-        if (inputDefinition.mode === "file") {
+        if (isMountedInput) {
           inputFileName = resolveInputFileName(invocation.uniqueId, inputDefinition)
           const fileContent = value.kind === "binary" ? new Blob([value.data]) : value.data;
           await CLI.mount({ name: inputFileName, data: fileContent })
@@ -406,7 +412,7 @@ export async function runTools(
 
           stdinValue = fileData?.data
         }
-        else if (inputDefinition.mode === "file" && inputDefinition.filename !== undefined) {
+        else if (isMountedInput && inputDefinition.filename !== undefined) {
           // The producing node named the file after its own output. Re-mount it
           // under the name this tool expects to see.
           const desiredFileName = resolveInputFileName(invocation.uniqueId, inputDefinition)


### PR DESCRIPTION
> **Merge order.** Stacked on #91 and targets `honour-input-filename`, not `main` — merge #91 first, then this. It is also the frontend half of a two-repo change: ieeta-pt/biochef-hub#26 adds the mode to the schema and is itself stacked on ieeta-pt/biochef-hub#25. **A recipe cannot use `mode: sidecar` until both repos have landed**, so neither half is useful alone, but neither breaks anything if it lands first.
>
> Full order: biochef-hub#25 → biochef-hub#26, and Biochef#91 → this. The two chains are independent of each other.

## Summary

Some tools locate a companion file by name rather than taking it as an argument. htslib resolves an index by string-appending `.csi` or `.bai` to the data file path, so `bcftools merge`, `isec` and `consensus` need a file at exactly `<datafile>.csi` that is **never** passed to the tool.

Today that is inexpressible. A `mode: file` input is always emitted — flagged, or positional if it has no flag — so declaring the index as an extra input hands it to the tool as a stray positional and the command fails. This is the gap noted in #91, which said the filename change alone would not unblock those operations.

This treats `mode: sidecar` exactly like a file input for **mounting**, and leaves the argument-building block untouched so a sidecar falls through it.

## Why the naming works out

The sidecar goes through the same resolver as every other input, so within one invocation:

| Declared | Mounted as |
|---|---|
| data input, `filename: a.vcf.gz` | `input-<nodeId>-a.vcf.gz` |
| sidecar, `filename: a.vcf.gz.csi` | `input-<nodeId>-a.vcf.gz.csi` |

The data file is passed to the tool as `input-<nodeId>-a.vcf.gz`; htslib appends `.csi` and finds the sidecar. The per-invocation prefix is on both, so the sibling relationship survives and names stay unique between nodes.

The upstream-node path is covered too: a sidecar piped from, say, a `samtools index` node is re-mounted under its declared name by the same code #91 added.

## Scope

`+8 −2`, all within the input-preparation loop. The argument-building block is deliberately not touched — that is what makes a sidecar invisible to argv.

## Verification

- **Inert until adopted** — no recipe declares `mode: sidecar` on any ref of `biochef-recipes` (it could not, until the hub change lands), so the new path is unreachable and nothing existing changes behaviour.
- **Build** — `npm run build`: `webpack 5.106.2 compiled successfully`.

No automated tests: the repo has no test script and no workflow runs on a PR here. As with #91, the substantive evidence is that the changed path cannot execute for any recipe that exists today.



---

### Merge order

Stacked on #91 — **base it on `honour-input-filename`, not `main`**, and merge #91 first.

`src/utils/toolUtils.js` is where five open branches meet: #91, #92, #93, this one, and WildBunnie's `aioli-vendored` (#90). They all conflict there pairwise, so the order matters more than usual.
