### PR TITLE
Close the Aioli worker when a workflow run finishes

### DIFF
--- a/src/utils/toolUtils.js
+++ b/src/utils/toolUtils.js
@@ -333,6 +333,8 @@ export async function runTools(
     debug: false,
   });
 
+  try {
+
   // 1. Prepare the inputs
   for (const invocation of toolInvocations) {
     const toolDefinition = getTool(invocation.toolName)
@@ -448,6 +450,18 @@ export async function runTools(
   logger.log("[runMultipleTools] Results", outputs, errors);
 
   return { "outputs": outputs, "errors": errors }
+  } finally {
+    // Each run builds its own Aioli instance, and each owns a Web Worker holding
+    // the loaded tools and their wasm heaps. Without this they accumulate for the
+    // lifetime of the page, one per run, including when a run throws part way.
+    // Every output is materialised as a DataValue before this point, so nothing
+    // reads the worker's filesystem afterwards.
+    try {
+      await CLI.close()
+    } catch (err) {
+      logger.warn("[runMultipleTools] Failed to close the Aioli worker", err)
+    }
+  }
 }
 
 export function getToolInputByName(toolName, inputName) {


### PR DESCRIPTION
## Summary

`runTools` builds a new `Aioli` instance on every call, and each one owns a Web Worker holding the loaded tools and their wasm heaps. Nothing ever closed it, so workers accumulate for the lifetime of the page — one per run. Running a workflow ten times leaves ten workers alive, each still holding its tools.

This closes the worker when the run finishes.

## Why `finally` and not just before the return

The invocation loop has no error handling of its own. One concrete way it throws today: an upstream node that produces no file leaves `aioliReadFileHelper` returning `undefined`, and the stdin branch dereferences it — that `TypeError` propagates straight out of `runTools`. Closing only on the success path would leak on exactly the runs most likely to be repeated.

The close is itself wrapped, because failing to shut a worker down should not turn an otherwise successful run into a failed one.

## Safety

Every output is materialised as a `DataValue` before the function returns — the file reads and re-mounts all happen inside the loop — so nothing touches the worker's filesystem afterwards. `CLI.close()` is part of the vendored aioli's worker API (`async close(){ ... self.close() }`).

## Scope

**+14 / −0.** The body of the new `try` block is deliberately left at its existing indentation so the diff stays readable; re-indenting it would have touched ~320 lines for no functional reason.

## Verification

- `npm run build`: `webpack 5.106.2 compiled successfully`
- `git merge-tree` against every open branch in this repo — `honour-input-filename`, `input-sidecar-mount`, `aioli-vendored`, `docker`: **0 conflicts** each, so this is independent of the #91 → #92 chain rather than stacked on it.

No automated tests: the repo has no test script and no workflow runs on a PR here.

## Context

This is worth having on its own, but it also stops being optional if a larger runtime is ever loaded — a leaked 1 MB samtools worker is untidy, a leaked 20 MB one is not.



---

### Merge order

`src/utils/toolUtils.js` is where five open branches meet: #91, #92, #93, this one, and WildBunnie's `aioli-vendored` (#90). They all conflict there pairwise, so the order matters more than usual.

This is the smallest of them and should land early. Once #95 lands it becomes redundant — the `finally` there closes both the aioli and the webR worker — so merging this first and dropping the duplicate when #95 rebases is the cheaper direction.
