### PR TITLE
Add browser catalogue and artifact verification

### DIFF
--- a/example.env
+++ b/example.env
@@ -2,3 +2,4 @@ REGISTRY_URL=http://localhost:5000
 REPO_OWNER=Biochef
 REGISTRY_USERNAME=Biochef
 REGISTRY_PASSWORD=ghp_1234567890abcdefghijklmnopqrstuvwxYZ12
+BIOCHEF_CATALOG_PACKAGE="biochef-plugins-index"

--- a/src/pages/ToolsPage.js
+++ b/src/pages/ToolsPage.js
@@ -64,13 +64,16 @@ const ToolsPage = () => {
 
     const handleToolClick = async (tool) => {
         setLoadingTool(true);
-        await loadTool(tool.name);
-        setSelectedTool(tool);
-        setLoadingTool(false);
-        if(tourIsActive) tourMoveNext();
-
-        if (isMobile) {
-            setTab(2)
+        try {
+            const loaded = await loadTool(tool.name);
+            if (!loaded) return;
+            setSelectedTool(tool);
+            if(tourIsActive) tourMoveNext();
+            if (isMobile) setTab(2);
+        } catch (error) {
+            console.error("Tool loading failed", error);
+        } finally {
+            setLoadingTool(false);
         }
     };
 

--- a/src/pages/WorkflowPage.js
+++ b/src/pages/WorkflowPage.js
@@ -54,16 +54,18 @@ const WorkflowPage = () => {
   // load tool index on opening the page
   useEffect(() => {
     const fetchToolIndex = async () => {
-      await loadToolIndex();
-      setToolIndexLoaded(true);
+      const result = await loadToolIndex();
+      setToolIndexLoaded(!!result);
     };
 
     fetchToolIndex()
   }, []);
 
   const handleAddOperation = async (toolName) => {
-    await loadTool(toolName)
-    const tool = getTool(toolName)
+    const loaded = await loadTool(toolName);
+    if (!loaded) return;
+    const tool = getTool(toolName);
+    if (!tool) return;
     recipePanelRef.current.addWorkflowNode(tool);
   };
 

--- a/src/utils/artifactIntegrity.js
+++ b/src/utils/artifactIntegrity.js
@@ -1,0 +1,40 @@
+const SHA256_DIGEST_PATTERN = /^sha256:([a-f0-9]{64})$/i;
+
+function normaliseSha256Digest(expectedDigest) {
+  if (typeof expectedDigest !== "string") {
+    throw new Error("Missing expected SHA-256 digest");
+  }
+
+  const match = expectedDigest.match(SHA256_DIGEST_PATTERN);
+  if (!match) {
+    throw new Error(`Unsupported artifact digest format: ${expectedDigest}`);
+  }
+
+  return match[1].toLowerCase();
+}
+
+function bytesToHex(bytes) {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export async function sha256Hex(arrayBuffer) {
+  if (!globalThis.crypto?.subtle) {
+    throw new Error("Web Crypto digest API is not available");
+  }
+
+  const digest = await globalThis.crypto.subtle.digest("SHA-256", arrayBuffer);
+  return bytesToHex(new Uint8Array(digest));
+}
+
+export async function verifySha256Digest(arrayBuffer, expectedDigest, artifactLabel = "artifact") {
+  const expectedHex = normaliseSha256Digest(expectedDigest);
+  const actualHex = await sha256Hex(arrayBuffer);
+
+  if (actualHex !== expectedHex) {
+    throw new Error(
+      `${artifactLabel} digest mismatch: expected sha256:${expectedHex}, got sha256:${actualHex}`
+    );
+  }
+
+  return `sha256:${actualHex}`;
+}

--- a/src/utils/catalogTrust.js
+++ b/src/utils/catalogTrust.js
@@ -1,0 +1,136 @@
+import { sha256Hex } from "./artifactIntegrity.js";
+
+const CATALOG_SCHEMA = "biochef.verified-catalog.v1";
+const SIGNATURE_SCHEMA = "biochef.catalog-signature.v1";
+const CATALOG_MEDIA_TYPE = "application/vnd.biochef.verified-catalog+json";
+const CATALOG_SEQUENCE_PREFIX = "biochef.catalog.sequence";
+
+export const DEFAULT_CATALOG_PACKAGE = "biochef-plugins-index";
+export const DEFAULT_CATALOG_PUBLIC_JWK = JSON.stringify({
+  alg: "ES256",
+  crv: "P-256",
+  kid: "biochef-catalog-key",
+  kty: "EC",
+  use: "sig",
+  x: "96FNjTbbBMsn0LpaFDTJFToaxfBsCZcCTKkEjNJi_js",
+  y: "mwG_hO5F6omiyrCD73nj4A4JCnaGheVHj9PuxpGHdf4",
+});
+
+function base64UrlToBytes(value) {
+  const padded = value + "=".repeat((4 - value.length % 4) % 4);
+  const base64 = padded.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(base64);
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+function parsePublicJwk(publicJwkJson) {
+  if (!publicJwkJson) {
+    throw new Error("Catalog public key is not configured");
+  }
+
+  const jwk = JSON.parse(publicJwkJson);
+  if (jwk.kty !== "EC" || jwk.crv !== "P-256" || jwk.alg !== "ES256") {
+    throw new Error("Catalog public key must be an ES256 P-256 JWK");
+  }
+  if (!jwk.kid || !jwk.x || !jwk.y) {
+    throw new Error("Catalog public key is missing kid/x/y");
+  }
+  return jwk;
+}
+
+async function importCatalogKey(jwk) {
+  return crypto.subtle.importKey(
+    "jwk",
+    jwk,
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["verify"],
+  );
+}
+
+function normaliseRegistry(value) {
+  return String(value || "")
+    .replace(/^https?:\/\//, "")
+    .replace(/\/+$/, "")
+    .toLowerCase();
+}
+
+function expectedRegistryNamespace(registryUrl, repoOwner) {
+  const registry = normaliseRegistry(registryUrl);
+  if (registry.includes("ghcr.io")) {
+    return `${registry}/${String(repoOwner || "").toLowerCase()}`;
+  }
+  return registry;
+}
+
+function requireCatalog(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function checkCatalogRollback(catalog) {
+  if (typeof localStorage === "undefined") return;
+
+  const key = `${CATALOG_SEQUENCE_PREFIX}.${catalog.registry}.${catalog.package_prefix}.${catalog.channel}`;
+  const previous = Number(localStorage.getItem(key) || "0");
+  const current = Number(catalog.sequence);
+  requireCatalog(Number.isSafeInteger(current) && current > 0, "Catalog sequence is invalid");
+  requireCatalog(current >= previous, "Catalog sequence rollback detected");
+  localStorage.setItem(key, String(current));
+}
+
+export async function verifySignedCatalog(catalogBytes, signatureDocument, publicJwkJson, expectedRegistryUrl, repoOwner) {
+  requireCatalog(signatureDocument?.schema === SIGNATURE_SCHEMA, "Catalog signature schema is invalid");
+  requireCatalog(signatureDocument.alg === "ES256", "Catalog signature algorithm is not supported");
+  requireCatalog(signatureDocument.signed_media_type === CATALOG_MEDIA_TYPE, "Catalog signed media type is invalid");
+  requireCatalog(typeof signatureDocument.signature === "string", "Catalog signature is missing");
+  requireCatalog(typeof signatureDocument.signed_digest === "string", "Catalog signed digest is missing");
+
+  const actualDigest = `sha256:${await sha256Hex(catalogBytes)}`;
+  requireCatalog(actualDigest === signatureDocument.signed_digest.toLowerCase(), "Catalog bytes do not match the signed digest");
+
+  const publicJwk = parsePublicJwk(publicJwkJson);
+  requireCatalog(publicJwk.kid === signatureDocument.keyid, "Catalog signature key id does not match pinned key");
+
+  const key = await importCatalogKey(publicJwk);
+  const valid = await crypto.subtle.verify(
+    { name: "ECDSA", hash: "SHA-256" },
+    key,
+    base64UrlToBytes(signatureDocument.signature),
+    catalogBytes,
+  );
+  requireCatalog(valid, "Catalog signature verification failed");
+
+  const catalogText = new TextDecoder("utf-8").decode(catalogBytes);
+  const catalog = JSON.parse(catalogText);
+  validateCatalog(catalog, expectedRegistryUrl, repoOwner);
+  return catalog;
+}
+
+export function validateCatalog(catalog, expectedRegistryUrl, repoOwner) {
+  requireCatalog(catalog?.schema === CATALOG_SCHEMA, "Catalog schema is not supported");
+  requireCatalog(catalog.channel, "Catalog channel is missing");
+  requireCatalog(catalog.version, "Catalog version is missing");
+  requireCatalog(normaliseRegistry(catalog.registry) === expectedRegistryNamespace(expectedRegistryUrl, repoOwner), "Catalog registry does not match configured registry");
+  requireCatalog(catalog.packages && typeof catalog.packages === "object", "Catalog packages are missing");
+  for (const entry of Object.values(catalog.packages)) {
+    validateCatalogEntry(entry);
+  }
+  checkCatalogRollback(catalog);
+}
+
+export function validateCatalogEntry(entry) {
+  requireCatalog(typeof entry?.id === "string" && entry.id, "Tool operation id is missing");
+  requireCatalog(typeof entry?.name === "string" && entry.name, "Tool name is missing");
+  requireCatalog(entry?.verification?.status === "passed", "Tool catalog entry is not verified");
+  requireCatalog(entry.verification.cosign_signature === "passed", "Tool signature verification did not pass");
+  requireCatalog(entry.verification.cyclonedx_attestation === "passed", "Tool CycloneDX attestation verification did not pass");
+  requireCatalog(entry.verification.slsa_provenance === "passed", "Tool SLSA provenance verification did not pass");
+  requireCatalog(typeof entry.digest_reference === "string" && entry.digest_reference.includes("@sha256:"), "Tool digest reference is not immutable");
+  requireCatalog(entry.package, "Tool package is missing");
+  requireCatalog(entry.version, "Tool version is missing");
+  requireCatalog(entry.evidence?.bundle_json, "Tool bundle evidence digest is missing");
+  requireCatalog(entry.runtime?.wasm?.wasm_digest, "Tool WASM digest is missing");
+  requireCatalog(entry.runtime?.wasm?.js_digest, "Tool JS digest is missing");
+}

--- a/src/utils/toolUtils.js
+++ b/src/utils/toolUtils.js
@@ -2,6 +2,13 @@ import Aioli from "./aioli-custom/aioli"
 import logger from "./logger";
 import { detectIsBinaryFile } from "./detectDataType";
 import { makeBinaryDataValue, makeTextDataValue } from './dataValue'
+import { verifySha256Digest } from "./artifactIntegrity";
+import {
+  DEFAULT_CATALOG_PACKAGE,
+  DEFAULT_CATALOG_PUBLIC_JWK,
+  validateCatalogEntry,
+  verifySignedCatalog,
+} from "./catalogTrust";
 
 const toolMap = new Map();
 const blobMap = new Map();
@@ -9,8 +16,14 @@ const REGISTRY_URL = process.env.REGISTRY_URL;
 const REPO_OWNER = process.env.REPO_OWNER;
 const REGISTRY_USERNAME = process.env.REGISTRY_USERNAME;
 const REGISTRY_PASSWORD = process.env.REGISTRY_PASSWORD;
+const CATALOG_PACKAGE = process.env.BIOCHEF_CATALOG_PACKAGE || DEFAULT_CATALOG_PACKAGE;
+const CATALOG_PUBLIC_JWK = process.env.BIOCHEF_CATALOG_PUBLIC_JWK || DEFAULT_CATALOG_PUBLIC_JWK;
 
 const IS_GHCR = REGISTRY_URL?.includes("ghcr.io") || false;
+
+function authorizationHeaders(authorization) {
+  return authorization ? { Authorization: authorization } : {};
+}
 
 // TODO: use ID instead of tool name
 export function getTool(toolName) {
@@ -93,7 +106,9 @@ async function getAuthorizationAndBaseUrl(repo) {
     };
   } else {
     return {
-      authorization: "Basic " + btoa(`${REGISTRY_USERNAME}:${REGISTRY_PASSWORD}`),
+      authorization: REGISTRY_USERNAME && REGISTRY_PASSWORD
+        ? "Basic " + btoa(`${REGISTRY_USERNAME}:${REGISTRY_PASSWORD}`)
+        : null,
       base_url: `${REGISTRY_URL}/v2`,
     };
   }
@@ -104,7 +119,7 @@ async function fetchManifest(base_url, repo, tag, authorization) {
     const res = await fetch(`${base_url}/${repo}/manifests/${tag}`, {
       headers: {
         Accept: "application/vnd.oci.image.manifest.v1+json",
-        Authorization: authorization,
+        ...authorizationHeaders(authorization),
       },
     });
 
@@ -122,11 +137,17 @@ async function fetchManifest(base_url, repo, tag, authorization) {
 }
 
 async function fetchBlob(base_url, repo, digest, authorization, accept) {
+  const arrayBuffer = await fetchBlobBytes(base_url, repo, digest, authorization, accept);
+  if (!arrayBuffer) return false;
+  return JSON.parse(new TextDecoder("utf-8").decode(arrayBuffer));
+}
+
+async function fetchBlobBytes(base_url, repo, digest, authorization, accept) {
   try {
     const res = await fetch(`${base_url}/${repo}/blobs/${digest}`, {
       headers: {
         Accept: accept,
-        Authorization: authorization,
+        ...authorizationHeaders(authorization),
       },
     });
 
@@ -140,7 +161,7 @@ async function fetchBlob(base_url, repo, digest, authorization, accept) {
 
       return false;
     }
-    return await res.json();
+    return await res.arrayBuffer();
 
   } catch (err) {
     logger.error(`fetchBlob network error for ${repo}@${digest}`, err);
@@ -148,21 +169,56 @@ async function fetchBlob(base_url, repo, digest, authorization, accept) {
   }
 }
 
-export async function loadToolIndex() {
-  const { authorization, base_url } = await getAuthorizationAndBaseUrl("biochef-plugins-index");
-  if (!authorization || !base_url) return false
+function findLayer(manifest, mediaType, fileName) {
+  const matchingLayers = manifest.layers?.filter(
+    layer =>
+      layer.mediaType === mediaType &&
+      layer.annotations?.["org.opencontainers.image.title"] === fileName
+  );
+  return matchingLayers?.length === 1 ? matchingLayers[0] : null;
+}
 
-  const manifest = await fetchManifest(base_url, "biochef-plugins-index", "index", authorization);
+function digestFromReference(digestReference) {
+  const digest = digestReference?.split("@").pop();
+  if (!digest?.startsWith("sha256:")) {
+    throw new Error(`Invalid immutable digest reference: ${digestReference}`);
+  }
+  return digest;
+}
+
+export async function loadToolIndex() {
+  const { authorization, base_url } = await getAuthorizationAndBaseUrl(CATALOG_PACKAGE);
+  if (!base_url) return false
+
+  const manifest = await fetchManifest(base_url, CATALOG_PACKAGE, "latest", authorization);
   if (!manifest) return false
 
-  const digest = manifest.layers[0].digest;
-  const indexJson = await fetchBlob(base_url, "biochef-plugins-index", digest, authorization, "application/vnd.oci.image.manifest.v1+json");
+  const catalogLayer = findLayer(manifest, "application/vnd.biochef.verified-catalog+json", "index.json");
+  const signatureLayer = findLayer(manifest, "application/vnd.biochef.catalog-signature+json", "index.sig.json");
+  if (!catalogLayer || !signatureLayer) {
+    logger.error("Verified catalog or catalog signature layer is missing");
+    return false;
+  }
 
-  for (const [key, plugin] of Object.entries(indexJson)) {
-    const bundle = {
+  const catalogBytes = await fetchBlobBytes(base_url, CATALOG_PACKAGE, catalogLayer.digest, authorization, "application/vnd.biochef.verified-catalog+json");
+  const signatureDocument = await fetchBlob(base_url, CATALOG_PACKAGE, signatureLayer.digest, authorization, "application/vnd.biochef.catalog-signature+json");
+  if (!catalogBytes || !signatureDocument) return false
+
+  const catalog = await verifySignedCatalog(catalogBytes, signatureDocument, CATALOG_PUBLIC_JWK, REGISTRY_URL, REPO_OWNER);
+
+  const verifiedTools = [];
+  for (const [key, plugin] of Object.entries(catalog.packages)) {
+    validateCatalogEntry(plugin);
+    verifiedTools.push({
       ...plugin,
-      repo: key
-    };
+      repo: plugin.package || key,
+      catalogEntry: plugin,
+    });
+  }
+
+  // Replace the visible catalogue only after every entry has passed validation.
+  toolMap.clear();
+  for (const bundle of verifiedTools) {
     toolMap.set(bundle.name, bundle);
   }
 
@@ -180,53 +236,67 @@ export async function loadTool(toolName) {
 
   const repo = bundleEntry.repo;
   const { authorization, base_url } = await getAuthorizationAndBaseUrl(repo);
-  if (!authorization || !base_url) return false;
+  if (!base_url) return false;
 
-  const manifest = await fetchManifest(base_url, repo, "latest", authorization);
+  validateCatalogEntry(bundleEntry.catalogEntry || bundleEntry);
+  const manifest = await fetchManifest(base_url, repo, digestFromReference(bundleEntry.digest_reference), authorization);
   if (!manifest) return false;
 
-  const bundleLayer = manifest.layers.find(
-    layer =>
-      layer.mediaType === "application/vnd.biochef.bundle+json" ||
-      layer.annotations?.["org.opencontainers.image.title"] === "bundle.json"
-  );
+  const bundleLayer = findLayer(manifest, "application/vnd.biochef.bundle+json", "bundle.json");
 
   if (!bundleLayer) {
     console.error(`No bundle.json layer found for ${repo}`);
     return;
   }
 
-  var bundle = await fetchBlob(base_url, repo, bundleLayer.digest, authorization, "application/vnd.oci.image.manifest.v1+json");
+  const bundleBytes = await fetchBlobBytes(base_url, repo, bundleLayer.digest, authorization, "application/vnd.biochef.bundle+json");
+  if (!bundleBytes) return false;
+  await verifySha256Digest(bundleBytes, bundleEntry.evidence.bundle_json, `${repo}/bundle.json`);
+  var bundle = JSON.parse(new TextDecoder("utf-8").decode(bundleBytes));
   if (!bundle) return false
 
-  bundle = { ...toolMap.get(bundle.name), ...bundle }
+  if (
+    bundle.id !== bundleEntry.id ||
+    bundle.name !== bundleEntry.name ||
+    bundle.version !== bundleEntry.version ||
+    bundle.runtime?.wasm?.wasm_digest !== bundleEntry.runtime.wasm.wasm_digest ||
+    bundle.runtime?.wasm?.js_digest !== bundleEntry.runtime.wasm.js_digest
+  ) {
+    logger.error(`Loaded bundle does not match verified catalog entry for ${repo}`);
+    return false;
+  }
+
+  bundle = { ...bundleEntry, ...bundle }
 
   bundle.repo = repo;
-  toolMap.set(bundle.name, bundle);
+  bundle.catalogEntry = bundleEntry.catalogEntry;
+  toolMap.set(toolName, bundle);
 
   return true
 }
 
-async function generateBlob(url, type, authorization) {
-  if (blobMap.has(url)) return blobMap.get(url);
+async function generateBlob(url, type, authorization, expectedDigest) {
+  const cacheKey = `${url}|${expectedDigest}`;
+  if (blobMap.has(cacheKey)) return blobMap.get(cacheKey);
 
   try {
     const res = await fetch(url, {
       headers: {
-        Authorization: authorization,
-        Accept: type
+        Accept: type,
+        ...authorizationHeaders(authorization),
       },
     });
     if (!res.ok) throw new Error(`Failed to fetch blob: ${res.status} ${res.statusText}`);
 
     const arrayBuffer = await res.arrayBuffer();
+    await verifySha256Digest(arrayBuffer, expectedDigest, url);
     const blob = new Blob([arrayBuffer], { type });
     const blobURL = URL.createObjectURL(blob);
-    blobMap.set(url, blobURL);
+    blobMap.set(cacheKey, blobURL);
     return blobURL;
   } catch (err) {
     console.error("Failed to load authenticated blob:", err);
-    return null;
+    throw err;
   }
 }
 
@@ -237,8 +307,8 @@ async function getToolBlobs(toolName) {
 
   const wasmUrl = `${base_url}/${toolConfig.repo}/blobs/${toolConfig.runtime.wasm.wasm_digest}`
   const jsUrl = `${base_url}/${toolConfig.repo}/blobs/${toolConfig.runtime.wasm.js_digest}`
-  const wasmBlob = await generateBlob(wasmUrl, "application/wasm", authorization)
-  const jsBlob = await generateBlob(jsUrl, "application/javascript", authorization)
+  const wasmBlob = await generateBlob(wasmUrl, "application/wasm", authorization, toolConfig.runtime.wasm.wasm_digest)
+  const jsBlob = await generateBlob(jsUrl, "application/javascript", authorization, toolConfig.runtime.wasm.js_digest)
 
   return [wasmBlob, jsBlob]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,6 +77,8 @@ module.exports = {
       "process.env.REPO_OWNER": JSON.stringify(process.env.REPO_OWNER),
       "process.env.REGISTRY_USERNAME": JSON.stringify(process.env.REGISTRY_USERNAME),
       "process.env.REGISTRY_PASSWORD": JSON.stringify(process.env.REGISTRY_PASSWORD),
+      "process.env.BIOCHEF_CATALOG_PACKAGE": JSON.stringify(process.env.BIOCHEF_CATALOG_PACKAGE),
+      "process.env.BIOCHEF_CATALOG_PUBLIC_JWK": JSON.stringify(process.env.BIOCHEF_CATALOG_PUBLIC_JWK),
     }),
   ],
   resolve: {


### PR DESCRIPTION
## Summary

This PR adds browser-side verification for artifacts introduced in ieeta-pt/biochef-hub#36 and ieeta-pt/biochef-recipes#93.

The frontend verifies the signed catalogue before exposing its tools and checks the exact bundle and runtime files before execution

Depends on the successful merge of ieeta-pt/biochef-hub#36 and ieeta-pt/biochef-recipes#93, followed by the complete recipe redeploy.

## Changes

- Verify the catalogue signature using the public key pinned in the frontend.
- Accept only catalogue entries that passed the required publication checks.
- Load operation bundles using immutable OCI manifest digests.
- Verify the bundle, JavaScript, and WebAssembly SHA-256 digests before execution.
- Prevent tools from being selected or added to workflows when verification fails.

Until the redeploy of the recipes and the matching catalogue, this branch can be tested using `biochef-port-plugins-index` which uses the successful publish run of the sbom-recipe-evidence branch.